### PR TITLE
Fix build image action

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -65,12 +65,14 @@ jobs:
         id: go
       - name: Checkout the code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - name: Install Mockgen
         run: go get github.com/golang/mock/mockgen@v1.4.4
       - name: Get dependencies
         run:  go mod download
       - name: Build csm-replication Docker Images
-        run: make images 
+        run: make images
   image_security_scan:
     name: Image Scanner
     needs: build_images    


### PR DESCRIPTION
we rely on tags to build images

# Description

git source checkout action by default fetches last commit only and ignores tags. Our build requires tags.

# Issues

List the issues impacted by this PR:

| Issue ID |
| -------- |
|          |

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have run 'make check' to ensure my code does not have any formatting, vetting, linting, or security issues
- [ ] I have run 'make test' to ensure new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degrade
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
