### PR TITLE
Updated ubi-min image version to newer used by drivers

### DIFF
--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -24,7 +24,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o dell-rep
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o dell-csi-replicator sidecar.go
 
 # Base image for controller and sidecar
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS container-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:e0814339ffc6c933652bed0c5f8b6416b9a3d40be2f49f95e6e4128387d2a24a AS container-base
 RUN microdnf update -y \
 && \
 microdnf clean all

--- a/Dockerfiles/Dockerfile.dev
+++ b/Dockerfiles/Dockerfile.dev
@@ -1,5 +1,5 @@
 # Base image for controller and sidecar
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS container-base
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:e0814339ffc6c933652bed0c5f8b6416b9a3d40be2f49f95e6e4128387d2a24a AS container-base
 RUN microdnf update -y \
 && \
 microdnf clean all


### PR DESCRIPTION
# Description
Updated ubi-min image version to newer used by drivers
(in PRs  https://github.com/dell/csi-powerscale/pull/30 and https://github.com/dell/csi-powermax/pull/33 for example)

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/102 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility
