### PR TITLE
Added hostAliases to helm's values

### DIFF
--- a/helm/csm-replication/templates/controller.yaml
+++ b/helm/csm-replication/templates/controller.yaml
@@ -223,6 +223,14 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      {{- if hasKey .Values "hostAliases" }}
+      {{ if .Values.hostAliases.enableHostAliases }}
+      hostAliases:
+      - ip: {{.Values.hostAliases.ip}}
+        hostnames:
+        - {{.Values.hostAliases.hostName}}
+      {{ end }}
+      {{- end }}
       containers:
       - args:
         - prefix=replication.storage.dell.com

--- a/helm/csm-replication/values.yaml
+++ b/helm/csm-replication/values.yaml
@@ -26,3 +26,9 @@ retryIntervalMin: 1s
 # retryIntervalMax: Maximum retry interval of failed reconcile request
 # Allowed values: time
 retryIntervalMax: 5m
+
+# HostAliases: Optional features that allows <hostname:IP> entry injection into pod's /etc/hosts file
+hostAliases:
+  enableHostAliases: false
+  hostName: "foo.bar"
+  ip: "10.10.10.10"


### PR DESCRIPTION
# Description
Adds support for closed OS networks by enabling ability to specify .spec.hostAliases during installation

# How Has This Been Tested?
Manually in real env
