### PR TITLE
Update allowedlist.yaml

### DIFF
--- a/.github/containerscan/allowedlist.yaml
+++ b/.github/containerscan/allowedlist.yaml
@@ -2,3 +2,4 @@ general:
   vulnerabilities:
     - CVE-2019-1010022 # "Will not fix", see https://access.redhat.com/security/cve/CVE-2019-1010022
     - CVE-2019-5827    # "Will not fix", see https://access.redhat.com/security/cve/cve-2019-5827
+    - CVE-2022-27664   # "Will not fix", see https://access.redhat.com/security/cve/cve-2022-27664


### PR DESCRIPTION
# Description
Added CVE-2022-27664 to the allow list so that image scanning does not fail.  There is currently no fix for this as per https://access.redhat.com/security/cve/cve-2022-27664

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| N/A |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
