### PR TITLE
Repctl tool update to support new storage class parameters for PowerScale replication

### DIFF
--- a/repctl/examples/powerscale_example_values.yaml
+++ b/repctl/examples/powerscale_example_values.yaml
@@ -11,9 +11,16 @@ parameters:
   rpo: "Five_Minutes"
   ignoreNamespaces: "false"
   volumeGroupPrefix: "csi"
-  accessZone: "System"
   isiPath: "/ifs/data/csi"
-  rootClientEnabled: "false"
   clusterName:
     source: "cluster-1"
     target: "cluster-2"
+  rootClientEnabled:
+    source: "false"
+    target: "false"
+  accessZone:
+    source: "System"
+    target: "System"
+  #azServiceIP:
+    #source: "192.168.1.1"
+    #target: "192.168.1.2"

--- a/repctl/pkg/cmd/create.go
+++ b/repctl/pkg/cmd/create.go
@@ -62,9 +62,10 @@ type GlobalParameters struct {
 
 	// PowerScale
 	ClusterName       Mirrored
-	AccessZone        string
+	AccessZone        Mirrored
+	AzServiceIP       Mirrored
 	IsiPath           string
-	RootClientEnabled bool
+	RootClientEnabled Mirrored
 
 	// Unity
 	Protocol    string

--- a/repctl/pkg/cmd/create.go
+++ b/repctl/pkg/cmd/create.go
@@ -372,7 +372,7 @@ func createSCs(scConfig ScConfig, clusters *k8s.Clusters, dryRun bool) error {
 			log.Print("Creating storage class in source cluster")
 			_, err := cluster.CreateObject(context.Background(), srcSC)
 			if err != nil {
-				log.Printf("Encountered error during creating object. Error: %s\n",
+				log.Errorf("Encountered error during creating object. Error: %s\n",
 					err.Error())
 				continue
 			}
@@ -382,7 +382,7 @@ func createSCs(scConfig ScConfig, clusters *k8s.Clusters, dryRun bool) error {
 			log.Print("Creating storage class in target cluster")
 			_, err := cluster.CreateObject(context.Background(), tgtSC)
 			if err != nil {
-				log.Printf("Encountered error during creating object. Error: %s\n",
+				log.Errorf("Encountered error during creating object. Error: %s\n",
 					err.Error())
 				continue
 			}

--- a/repctl/pkg/cmd/templates/isilon_source.yaml
+++ b/repctl/pkg/cmd/templates/isilon_source.yaml
@@ -21,12 +21,12 @@ parameters:
   {{ .ReplicationPrefix }}/remoteRGRetentionPolicy: {{ .RemoteRetentionPolicy.RG }}
   {{ .ReplicationPrefix }}/remotePVRetentionPolicy: {{ .RemoteRetentionPolicy.PV }}
   {{ .ReplicationPrefix }}/remoteAccessZone: {{ .Parameters.AccessZone.Target }}
-  {{- if .Parameters.AzServiceIP }}
+  {{- if .Parameters.AzServiceIP.Target }}
   {{ .ReplicationPrefix }}/remoteAzServiceIP: {{ .Parameters.AzServiceIP.Target }}
   {{- end }}
-  {{ .ReplicationPrefix }}/remoteRootClientEnabled: {{ .Parameters.RootClientEnabled.Target }}
+  {{ .ReplicationPrefix }}/remoteRootClientEnabled: "{{ .Parameters.RootClientEnabled.Target }}"
   AccessZone: {{ .Parameters.AccessZone.Source }}
-  {{- if .Parameters.AzServiceIP }}
+  {{- if .Parameters.AzServiceIP.Source }}
   AzServiceIP: {{ .Parameters.AzServiceIP.Source }}
   {{- end }}
   IsiPath: {{ .Parameters.IsiPath}}

--- a/repctl/pkg/cmd/templates/isilon_source.yaml
+++ b/repctl/pkg/cmd/templates/isilon_source.yaml
@@ -20,8 +20,15 @@ parameters:
   {{ .ReplicationPrefix }}/remoteSystem: {{ .Parameters.ClusterName.Target }}
   {{ .ReplicationPrefix }}/remoteRGRetentionPolicy: {{ .RemoteRetentionPolicy.RG }}
   {{ .ReplicationPrefix }}/remotePVRetentionPolicy: {{ .RemoteRetentionPolicy.PV }}
-  AccessZone: {{ .Parameters.AccessZone}}
+  {{ .ReplicationPrefix }}/remoteAccessZone: {{ .Parameters.AccessZone.Target }}
+  {{- if .Parameters.AzServiceIP }}
+  {{ .ReplicationPrefix }}/remoteAzServiceIP: {{ .Parameters.AzServiceIP.Target }}
+  {{- end }}
+  {{ .ReplicationPrefix }}/remoteRootClientEnabled: {{ .Parameters.RootClientEnabled.Target }}
+  AccessZone: {{ .Parameters.AccessZone.Source }}
+  {{- if .Parameters.AzServiceIP }}
+  AzServiceIP: {{ .Parameters.AzServiceIP.Source }}
+  {{- end }}
   IsiPath: {{ .Parameters.IsiPath}}
-  RootClientEnabled: "{{ .Parameters.RootClientEnabled }}"
+  RootClientEnabled: "{{ .Parameters.RootClientEnabled.Source }}"
   ClusterName: {{ .Parameters.ClusterName.Source }}
-

--- a/repctl/pkg/cmd/templates/isilon_target.yaml
+++ b/repctl/pkg/cmd/templates/isilon_target.yaml
@@ -24,12 +24,12 @@ parameters:
   {{ .ReplicationPrefix }}/remoteRGRetentionPolicy: {{ .RemoteRetentionPolicy.RG }}
   {{ .ReplicationPrefix }}/remotePVRetentionPolicy: {{ .RemoteRetentionPolicy.PV }}
   {{ .ReplicationPrefix }}/remoteAccessZone: {{ .Parameters.AccessZone.Source }}
-  {{- if .Parameters.AzServiceIP }}
+  {{- if .Parameters.AzServiceIP.Source }}
   {{ .ReplicationPrefix }}/remoteAzServiceIP: {{ .Parameters.AzServiceIP.Source }}
   {{- end }}
-  {{ .ReplicationPrefix }}/remoteRootClientEnabled: {{ .Parameters.RootClientEnabled.Source }}
+  {{ .ReplicationPrefix }}/remoteRootClientEnabled: "{{ .Parameters.RootClientEnabled.Source }}"
   AccessZone: {{ .Parameters.AccessZone.Target }}
-  {{- if .Parameters.AzServiceIP }}
+  {{- if .Parameters.AzServiceIP.Target }}
   AzServiceIP: {{ .Parameters.AzServiceIP.Target }}
   {{- end }}
   IsiPath: {{ .Parameters.IsiPath}}

--- a/repctl/pkg/cmd/templates/isilon_target.yaml
+++ b/repctl/pkg/cmd/templates/isilon_target.yaml
@@ -23,8 +23,15 @@ parameters:
   {{ .ReplicationPrefix }}/remoteSystem: {{ .Parameters.ClusterName.Source }}
   {{ .ReplicationPrefix }}/remoteRGRetentionPolicy: {{ .RemoteRetentionPolicy.RG }}
   {{ .ReplicationPrefix }}/remotePVRetentionPolicy: {{ .RemoteRetentionPolicy.PV }}
-  AccessZone: {{ .Parameters.AccessZone}}
+  {{ .ReplicationPrefix }}/remoteAccessZone: {{ .Parameters.AccessZone.Source }}
+  {{- if .Parameters.AzServiceIP }}
+  {{ .ReplicationPrefix }}/remoteAzServiceIP: {{ .Parameters.AzServiceIP.Source }}
+  {{- end }}
+  {{ .ReplicationPrefix }}/remoteRootClientEnabled: {{ .Parameters.RootClientEnabled.Source }}
+  AccessZone: {{ .Parameters.AccessZone.Target }}
+  {{- if .Parameters.AzServiceIP }}
+  AzServiceIP: {{ .Parameters.AzServiceIP.Target }}
+  {{- end }}
   IsiPath: {{ .Parameters.IsiPath}}
-  RootClientEnabled: "{{ .Parameters.RootClientEnabled }}"
+  RootClientEnabled: "{{ .Parameters.RootClientEnabled.Target }}"
   ClusterName: {{ .Parameters.ClusterName.Target }}
-


### PR DESCRIPTION
# Description
Repctl tool update to support new storage class parameters for PowerScale replication. Please note that the changes are only in the repctl and does not affect replication module code.

PowerScale driver changes and documentation update are handled in their repos.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/514 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- Ran repctl tool to create storage classes on both source and target k8s clusters with different combination of newly added parameters.
- AzServiceIp is optional, so its generation is handled accordingly.
- Provisioning of PVs using the newly generated storage class is successful.