### PR TITLE
Add secret to default service account

### DIFF
--- a/deploy/controller.yaml
+++ b/deploy/controller.yaml
@@ -265,3 +265,66 @@ spec:
           name: dell-replication-controller-config
           optional: true
         name: configmap-volume
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+      "helm.sh/hook": pre-install
+      "helm.sh/hook-weight": "-5"
+      "helm.sh/hook-delete-policy": hook-succeeded
+  name: default
+  namespace: dell-replication-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+  name: default
+  namespace: dell-replication-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: default
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: dell-replication-controller
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: replication-secret
+  namespace: dell-replication-controller
+  annotations:
+    kubernetes.io/service-account.name: default
+    kubernetes.io/service-account.namespace: dell-replication-controller
+type: kubernetes.io/service-account-token
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-mountable-secret
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: sa
+        image: bitnami/kubectl
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh","-c", "kubectl patch serviceaccount default -p '{\"secrets\": [{\"name\": \"replication-secret\"}]}'"]

--- a/helm/csm-replication/templates/patch.yaml
+++ b/helm/csm-replication/templates/patch.yaml
@@ -1,0 +1,62 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations:
+      "helm.sh/hook": pre-install
+      "helm.sh/hook-weight": "-5"
+      "helm.sh/hook-delete-policy": hook-succeeded
+  name: default
+  namespace: dell-replication-controller
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+  name: default
+  namespace: dell-replication-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: default
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: dell-replication-controller
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: replication-secret
+  namespace: dell-replication-controller
+  annotations:
+    kubernetes.io/service-account.name: default
+    kubernetes.io/service-account.namespace: dell-replication-controller
+type: kubernetes.io/service-account-token
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-mountable-secret
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: sa
+        image: bitnami/kubectl
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/sh","-c", "kubectl patch serviceaccount default -p '{\"secrets\": [{\"name\": \"replication-secret\"}]}'"]


### PR DESCRIPTION
# Description
Patch the default service account through helm to generate the token and set the mountable secret to that token. This generation is needed with K8s 1.24+ since the secret is no longer automatically generated when a service account is created. Followed the process outlined [here](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#manually-create-a-service-account-api-token).

**Note:** A job is needed because during helm installation, modifying the default service account is not dynamically allowed. This is the automatic way of solving this issue otherwise, the user would need to `edit` the service account afterwards.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/463 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- Ensured that when installing the dell-replication-controller, the `default` service account contained the generated token and mountable secret.
- Ensured that running `repctl inject cluster --use-sa` no longer fails and properly creates the secrets on both the source and target cluster.
- Ensured that replication functionality still works after running the command above.
