### PR TITLE
Add new service account to be used

### DIFF
--- a/helm/csm-replication/templates/controller.yaml
+++ b/helm/csm-replication/templates/controller.yaml
@@ -1,3 +1,11 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dell-replication-controller-sa
+  namespace: dell-replication-controller
+secrets:
+- name: replication-secret
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -146,6 +154,16 @@ rules:
   verbs:
   - create
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: replication-secret
+  namespace: dell-replication-controller
+  annotations:
+    kubernetes.io/service-account.name: dell-replication-controller-sa
+    kubernetes.io/service-account.namespace: dell-replication-controller
+type: kubernetes.io/service-account-token
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -156,7 +174,7 @@ roleRef:
   name: dell-replication-manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: dell-replication-controller-sa
   namespace: dell-replication-controller
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -169,7 +187,7 @@ roleRef:
   name: dell-replication-proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: dell-replication-controller-sa
   namespace: dell-replication-controller
 ---
 {{- $secret := (lookup "v1" "ConfigMap" "dell-replication-controller" "dell-replication-controller-config").data -}}
@@ -227,6 +245,7 @@ spec:
       hostAliases:
       {{- toYaml .Values.hostAliases | nindent 6 }}
       {{- end }}
+      serviceAccountName: dell-replication-controller-sa
       containers:
       - args:
         - prefix=replication.storage.dell.com

--- a/repctl/pkg/cmd/cluster.go
+++ b/repctl/pkg/cmd/cluster.go
@@ -535,7 +535,7 @@ func generateConfigsFromSA(mc *k8s.MultiClusterConfigurator, clusterIDs []string
 		cfgPath := fmt.Sprintf("/tmp/repctl/%s", cluster.GetID())
 
 		// #nosec G204
-		c := exec.Command("/bin/bash", "/tmp/repctl/gen_kubeconfig.sh", "-s", "default", "-n", namespace, "-o", cfgPath)
+		c := exec.Command("/bin/bash", "/tmp/repctl/gen_kubeconfig.sh", "-s", "dell-replication-controller-sa", "-n", namespace, "-o", cfgPath)
 		c.Stdout = os.Stdout
 		c.Stderr = os.Stderr
 


### PR DESCRIPTION
# Description
Instead of using the `default` service account and trying to patch it to contain the correct secret, we create a new service account for the `dell-replication-controller` and use that throughout. This limits the pre-hook generation as modifying a new service account through helm is simple.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/463 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- Ensured that when installing the dell-replication-controller, the new service account contained the generated token and mountable secret.
- Ensured that running `repctl inject cluster --use-sa` no longer fails and properly creates the secrets on both the source and target cluster.
- Ensured that replication functionality still works after running the command above.
