### PR TITLE
Skip RG status poll/update if any action is being executed

### DIFF
--- a/repctl/pkg/cmd/failback.go
+++ b/repctl/pkg/cmd/failback.go
@@ -117,7 +117,7 @@ func failbackToRG(configFolder, rgName string, discard, verbose bool, wait bool)
 		return
 
 	}
-	log.Printf("RG (%s), successfully updated with action: faiback\n", rg.Name)
+	log.Printf("RG (%s), successfully updated with action: failback\n", rg.Name)
 }
 
 func failbackToCluster(configFolder, inputSourceCluster, rgName string, discard, verbose bool, wait bool) {
@@ -170,5 +170,5 @@ func failbackToCluster(configFolder, inputSourceCluster, rgName string, discard,
 		return
 
 	}
-	log.Printf("RG (%s), successfully updated with action: faiback\n", rg.Name)
+	log.Printf("RG (%s), successfully updated with action: failback\n", rg.Name)
 }


### PR DESCRIPTION
# Description
When RG status gets updated (as part of regular monitoring) when an action is in progress, the action result update fails. Due to that, the action gets executed again. So RG status polling is skipped when an action is being executed and the action anyways update the RG status at the end.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/558 |
| https://github.com/dell/csm/issues/532 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?

Tested all PowerScale replication actions and no issues are detected. Monitored the log w.r.t action and RG status poll.
[RG status poll log times.txt](https://github.com/dell/csm-replication/files/10230095/RG.status.poll.log.times.txt)