### PR TITLE
Bugfix/deploy service account

### DIFF
--- a/deploy/controller.yaml
+++ b/deploy/controller.yaml
@@ -3,6 +3,14 @@ kind: Namespace
 metadata:
   name: dell-replication-controller
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dell-replication-controller-sa
+  namespace: dell-replication-controller
+secrets:
+- name: replication-secret
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -151,6 +159,16 @@ rules:
   verbs:
   - create
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: replication-secret
+  namespace: dell-replication-controller
+  annotations:
+    kubernetes.io/service-account.name: dell-replication-controller-sa
+    kubernetes.io/service-account.namespace: dell-replication-controller
+type: kubernetes.io/service-account-token
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -161,7 +179,7 @@ roleRef:
   name: dell-replication-manager-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: dell-replication-controller-sa
   namespace: dell-replication-controller
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -174,7 +192,7 @@ roleRef:
   name: dell-replication-proxy-role
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: dell-replication-controller-sa
   namespace: dell-replication-controller
 ---
 apiVersion: v1
@@ -220,6 +238,7 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      serviceAccountName: dell-replication-controller-sa
       containers:
       - args:
         - --enable-leader-election

--- a/repctl/pkg/k8s/cluster.go
+++ b/repctl/pkg/k8s/cluster.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/repctl/pkg/k8s/cluster.go
+++ b/repctl/pkg/k8s/cluster.go
@@ -505,6 +505,26 @@ func (c *Cluster) CreateObject(ctx context.Context, data []byte) (runtime.Object
 			return nil, err
 		}
 		log.Print("Successfully created config map: ", cmObj.Name)
+	case *v1.ServiceAccount:
+		cmObj, ok := runtimeObj.(*v1.ServiceAccount)
+		if !ok {
+			return nil, fmt.Errorf("unsupported object type")
+		}
+		err := c.client.Create(ctx, cmObj)
+		if err != nil {
+			return nil, err
+		}
+		log.Print("Successfully created ServiceAccount: ", cmObj.Name)
+	case *v1.Secret:
+		cmObj, ok := runtimeObj.(*v1.Secret)
+		if !ok {
+			return nil, fmt.Errorf("unsupported object type")
+		}
+		err := c.client.Create(ctx, cmObj)
+		if err != nil {
+			return nil, err
+		}
+		log.Print("Successfully created Secret: ", cmObj.Name)
 	default:
 		return nil, fmt.Errorf("unsupported object type %+v", runtimeObj.GetObjectKind())
 	}


### PR DESCRIPTION
# Description
Update from https://github.com/dell/csm-replication/pull/62. There are two ways for installing `csm-replication`. This covers the all-in-one using `repctl` for installing instead of the installation script.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/600 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Installed `csm-replication` using `repctl`. Ensured that the correct service account and secret are created and that replication is running correctly.
