### PR TITLE
Add pflex support

### DIFF
--- a/repctl/examples/powerflex_example_values.yaml
+++ b/repctl/examples/powerflex_example_values.yaml
@@ -1,0 +1,22 @@
+sourceClusterID: "cluster-k211"
+targetClusterID: "cluster-k212"
+name: "vxflexos-replication"
+driver: "vxflexos"
+reclaimPolicy: "Delete"
+replicationPrefix: "replication.storage.dell.com"
+remoteRetentionPolicy:
+  RG: "Delete"
+  PV: "Retain"
+parameters:
+  storagePool: # populate with storage pool to use of arrays
+    source: "pool1"
+    target: "pool1"
+  protectionDomain: # populate with protection domain to use of arrays
+    source: "domain1"
+    target: "domain1"
+  arrayID: # populate with unique ids of storage arrays
+    source: "0000000000000001"
+    target: "0000000000000002"
+  rpo: "60"
+  volumeGroupPrefix: "csi"
+  consistencyGroupName: "" # optional name to be given to the rcg

--- a/repctl/pkg/cmd/create.go
+++ b/repctl/pkg/cmd/create.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2021-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/repctl/pkg/cmd/create.go
+++ b/repctl/pkg/cmd/create.go
@@ -70,6 +70,7 @@ type GlobalParameters struct {
 	// PowerFlex
 	ConsistencyGroupName string
 	ProtectionDomain     Mirrored
+	StoragePool          Mirrored
 }
 
 // RemoteRetentionPolicy structure that contains values for remoteRetentionPolicy for both PV and RGs

--- a/repctl/pkg/cmd/create.go
+++ b/repctl/pkg/cmd/create.go
@@ -66,6 +66,10 @@ type GlobalParameters struct {
 	AzServiceIP       Mirrored
 	IsiPath           string
 	RootClientEnabled Mirrored
+
+	// PowerFlex
+	ConsistencyGroupName string
+	ProtectionDomain     Mirrored
 }
 
 // RemoteRetentionPolicy structure that contains values for remoteRetentionPolicy for both PV and RGs
@@ -337,7 +341,7 @@ func createPVCs(providedPVList []string, cluster k8s.ClusterInterface, rgName, t
 
 func createSCs(scConfig ScConfig, clusters *k8s.Clusters, dryRun bool) error {
 	switch scConfig.Driver {
-	case "powerstore", "powermax", "isilon":
+	case "powerstore", "powermax", "isilon", "vxflexos":
 		break
 	default:
 		return fmt.Errorf("driver not supported")

--- a/repctl/pkg/cmd/templates/vxflexos_source.yaml
+++ b/repctl/pkg/cmd/templates/vxflexos_source.yaml
@@ -1,0 +1,33 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ .Name }}
+provisioner: csi-{{ .Driver }}.dellemc.com
+reclaimPolicy: {{ .ReclaimPolicy }}
+volumeBindingMode: Immediate
+allowVolumeExpansion: true
+parameters:
+  storagepool: {{ .Parameters.StoragePool.Source }}
+  systemID: {{ .Parameters.ArrayID.Source }}
+  protectiondomain: {{ .Parameters.ProtectionDomain.Source }}
+  {{ .ReplicationPrefix }}/isReplicationEnabled: "true"
+  {{- if eq .TargetClusterID .SourceClusterID }}
+  {{ .ReplicationPrefix }}/remoteStorageClassName: {{ .Name }}-tgt
+  {{ .ReplicationPrefix }}/remoteClusterID: self
+  {{- else }}
+  {{ .ReplicationPrefix }}/remoteStorageClassName: {{ .Name }}
+  {{ .ReplicationPrefix }}/remoteClusterID: {{ .TargetClusterID }}
+  {{- end }}
+  {{ .ReplicationPrefix }}/remoteSystem: {{ .Parameters.ArrayID.Target }}
+  {{ .ReplicationPrefix }}/remoteStoragePool: {{ .Parameters.StoragePool.Target }}
+  {{ .ReplicationPrefix }}/rpo: "{{ .Parameters.Rpo }}"
+  {{ .ReplicationPrefix }}/volumeGroupPrefix: {{ .Parameters.VolumeGroupPrefix }}
+  {{ .ReplicationPrefix }}/remoteRGRetentionPolicy: {{ .RemoteRetentionPolicy.RG }}
+  {{ .ReplicationPrefix }}/remotePVRetentionPolicy: {{ .RemoteRetentionPolicy.PV }}
+  {{ .ReplicationPrefix }}/consistencyGroupName: {{ .Parameters.ConsistencyGroupName }}
+  {{ .ReplicationPrefix }}/protectionDomain: {{ .Parameters.ProtectionDomain.Target }}
+allowedTopologies:
+- matchLabelExpressions:
+  - key: csi-{{ .Driver }}.dellemc.com/{{ .Parameters.RemoteSystem.Source }}
+    values:
+    - csi-{{ .Driver }}.dellemc.com

--- a/repctl/pkg/cmd/templates/vxflexos_source.yaml
+++ b/repctl/pkg/cmd/templates/vxflexos_source.yaml
@@ -28,6 +28,6 @@ parameters:
   {{ .ReplicationPrefix }}/protectionDomain: {{ .Parameters.ProtectionDomain.Target }}
 allowedTopologies:
 - matchLabelExpressions:
-  - key: csi-{{ .Driver }}.dellemc.com/{{ .Parameters.RemoteSystem.Source }}
+  - key: csi-{{ .Driver }}.dellemc.com/{{ .Parameters.ArrayID.Source }}
     values:
     - csi-{{ .Driver }}.dellemc.com

--- a/repctl/pkg/cmd/templates/vxflexos_target.yaml
+++ b/repctl/pkg/cmd/templates/vxflexos_target.yaml
@@ -1,0 +1,36 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  {{- if eq .TargetClusterID .SourceClusterID }}
+  name: {{ .Name }}-tgt
+  {{- else }}
+  name: {{ .Name }}
+  {{- end }}
+provisioner: csi-{{ .Driver }}.dellemc.com
+reclaimPolicy: {{ .ReclaimPolicy }}
+volumeBindingMode: Immediate
+allowVolumeExpansion: true
+parameters:
+  storagepool: {{ .Parameters.StoragePool.Target }}
+  systemID: {{ .Parameters.ArrayID.Target }}
+  protectiondomain: {{ .Parameters.ProtectionDomain.Target }}
+  {{ .ReplicationPrefix }}/isReplicationEnabled: "true"
+  {{ .ReplicationPrefix }}/remoteStorageClassName: {{ .Name }}
+  {{- if eq .TargetClusterID .SourceClusterID }}
+  {{ .ReplicationPrefix }}/remoteClusterID: self
+  {{- else }}
+  {{ .ReplicationPrefix }}/remoteClusterID: {{ .SourceClusterID }}
+  {{- end }}
+  {{ .ReplicationPrefix }}/remoteSystem: {{ .Parameters.ArrayID.Source }}
+  {{ .ReplicationPrefix }}/remoteStoragePool: {{ .Parameters.StoragePool.Source }}
+  {{ .ReplicationPrefix }}/rpo: "{{ .Parameters.Rpo }}"
+  {{ .ReplicationPrefix }}/volumeGroupPrefix: {{ .Parameters.VolumeGroupPrefix }}
+  {{ .ReplicationPrefix }}/remoteRGRetentionPolicy: {{ .RemoteRetentionPolicy.RG }}
+  {{ .ReplicationPrefix }}/remotePVRetentionPolicy: {{ .RemoteRetentionPolicy.PV }}
+  {{ .ReplicationPrefix }}/consistencyGroupName: {{ .Parameters.ConsistencyGroupName }}
+  {{ .ReplicationPrefix }}/protectionDomain: {{ .Parameters.ProtectionDomain.Source }}
+allowedTopologies:
+- matchLabelExpressions:
+  - key: csi-{{ .Driver }}.dellemc.com/{{ .Parameters.RemoteSystem.Target }}
+    values:
+    - csi-{{ .Driver }}.dellemc.com

--- a/repctl/pkg/cmd/templates/vxflexos_target.yaml
+++ b/repctl/pkg/cmd/templates/vxflexos_target.yaml
@@ -31,6 +31,6 @@ parameters:
   {{ .ReplicationPrefix }}/protectionDomain: {{ .Parameters.ProtectionDomain.Source }}
 allowedTopologies:
 - matchLabelExpressions:
-  - key: csi-{{ .Driver }}.dellemc.com/{{ .Parameters.RemoteSystem.Target }}
+  - key: csi-{{ .Driver }}.dellemc.com/{{ .Parameters.ArrayID.Target }}
     values:
     - csi-{{ .Driver }}.dellemc.com


### PR DESCRIPTION
# Description
Adds support of `PowerFlex` to `repctl`. This will allow the creation of storage classes with the appropriate template using `repctl` for PowerFlex.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/618 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Using `repctl`, ensure that the creation of replicated storage class for PowerFlex is created.
