### PR TITLE
Add Namespace Creation on Snapshot Action

### DIFF
--- a/deploy/controller.yaml
+++ b/deploy/controller.yaml
@@ -61,6 +61,7 @@ rules:
   resources:
   - namespaces
   verbs:
+  - create
   - get
   - list
   - watch

--- a/helm/csm-replication/templates/controller.yaml
+++ b/helm/csm-replication/templates/controller.yaml
@@ -56,6 +56,7 @@ rules:
   resources:
   - namespaces
   verbs:
+  - create
   - get
   - list
   - watch

--- a/pkg/connection/interface.go
+++ b/pkg/connection/interface.go
@@ -43,6 +43,8 @@ type RemoteClusterClient interface {
 	CreateSnapshotContent(ctx context.Context, content *s1.VolumeSnapshotContent) error
 	CreateSnapshotObject(ctx context.Context, content *s1.VolumeSnapshot) error
 	GetSnapshotClass(ctx context.Context, snapClassName string) (*s1.VolumeSnapshotClass, error)
+	CreateNamespace(ctx context.Context, content *corev1.Namespace) error
+	GetNamespace(ctx context.Context, namespace string) (*corev1.Namespace, error)
 }
 
 // ConnHandler - Interface

--- a/pkg/connection/k8sconnections.go
+++ b/pkg/connection/k8sconnections.go
@@ -287,12 +287,12 @@ func (c *RemoteK8sControllerClient) GetSnapshotClass(ctx context.Context, snapCl
 	return found, nil
 }
 
-// CreateNamespace creates a desired namespace on the remote cluster
+// CreateNamespace creates a desired namespace on the remote cluster.
 func (c *RemoteK8sControllerClient) CreateNamespace(ctx context.Context, content *corev1.Namespace) error {
 	return c.Client.Create(ctx, content)
 }
 
-// GetNamespace creates a desired namespace on the remote cluster
+// GetNamespace returns the desired namespace from the remote cluster.
 func (c *RemoteK8sControllerClient) GetNamespace(ctx context.Context, namespace string) (*corev1.Namespace, error) {
 	found := &corev1.Namespace{}
 

--- a/pkg/connection/k8sconnections.go
+++ b/pkg/connection/k8sconnections.go
@@ -283,6 +283,24 @@ func (c *RemoteK8sControllerClient) GetSnapshotClass(ctx context.Context, snapCl
 	if err != nil {
 		return nil, err
 	}
+
+	return found, nil
+}
+
+// CreateNamespace creates a desired namespace on the remote cluster
+func (c *RemoteK8sControllerClient) CreateNamespace(ctx context.Context, content *corev1.Namespace) error {
+	return c.Client.Create(ctx, content)
+}
+
+// GetNamespace creates a desired namespace on the remote cluster
+func (c *RemoteK8sControllerClient) GetNamespace(ctx context.Context, namespace string) (*corev1.Namespace, error) {
+	found := &corev1.Namespace{}
+
+	err := c.Client.Get(ctx, types.NamespacedName{Name: namespace}, found)
+	if err != nil {
+		return nil, err
+	}
+
 	return found, nil
 }
 

--- a/repctl/pkg/cmd/snapshot.go
+++ b/repctl/pkg/cmd/snapshot.go
@@ -34,8 +34,7 @@ func GetSnapshotCommand() *cobra.Command {
 For single cluster config:
 ./repctl --rg <rg-id> --sn-namespace <namespace> --sn-class <snapshot class> snapshot`,
 		Long: `
-This command will perform a snapshot at specified cluster or at the RG.\n
-Note: More information to be added.`,
+This command will create a snapshot for the specified RG on the target cluster.\n`,
 		Run: func(cmd *cobra.Command, args []string) {
 			rgName := viper.GetString(config.ReplicationGroup)
 			inputCluster := viper.GetString("target")


### PR DESCRIPTION
# Description
This is an enhancement to the snapshot action handling in the controller. As requested, this checks to see if the desired namespace exists, if it doesn't then it attempts to create it.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/618 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested on PowerFlex with the snapshot action in `repctl`. Tested both approaches: if the namespace exists, use it for creating the remote snapshot objects, and if the namespace doesn't exist, create it and ensure that the snapshot objects are created in that namespace.