### PR TITLE
Retrieve Cluster UID

### DIFF
--- a/cmd/csi-replicator/main.go
+++ b/cmd/csi-replicator/main.go
@@ -50,7 +50,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
-	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
@@ -233,9 +232,8 @@ func main() {
 	logrusLog.SetLevel(level)
 
 	// Get the kube-system content
-	er := mgr.GetEventRecorderFor(common.DellReplicationController)
 	var clusterUID string
-	ns, err := getClusterUID(ctx, er)
+	ns, err := getClusterUID(ctx)
 	if err != nil {
 		log.Println("getClusterUuid error: ", err.Error())
 	} else {
@@ -316,7 +314,7 @@ func main() {
 
 }
 
-func getClusterUID(ctx context.Context, recorder record.EventRecorder) (*v1.Namespace, error) {
+func getClusterUID(ctx context.Context) (*v1.Namespace, error) {
 	client, err := connection.GetControllerClient(nil, scheme)
 	if err != nil {
 		return nil, err

--- a/controllers/constants.go
+++ b/controllers/constants.go
@@ -120,4 +120,8 @@ const (
 	snapshotNamespace = "/snapshotNamespace"
 	// Indicates the time which the last action was processed.
 	actionProcessedTime = "/actionProcessedTime"
+	// KubeSystemNamespace indicates the namespace of the system which the controller is installed on.
+	KubeSystemNamespace = "kube-system"
+	// ClusterUID indicates the clusterUID retrieved from the KubeSystem.
+	ClusterUID = "clusterUID"
 )

--- a/controllers/csi-replicator/dellcsireplicationgroup_controller.go
+++ b/controllers/csi-replicator/dellcsireplicationgroup_controller.go
@@ -145,8 +145,6 @@ func updateRGSpecWithActionResult(ctx context.Context, rg *repv1.DellCSIReplicat
 			actionAnnotation.SnapshotClass = snClass
 		}
 
-		log.V(common.InfoLevel).Info("ActionAnnotation - " + actionAnnotation.SnapshotNamespace + " " + controllers.SnapshotNamespace)
-
 		bytes, _ := json.Marshal(&actionAnnotation)
 		controllers.AddAnnotation(rg, Action, string(bytes))
 

--- a/controllers/csi-replicator/persistentvolume_controller.go
+++ b/controllers/csi-replicator/persistentvolume_controller.go
@@ -51,6 +51,7 @@ type PersistentVolumeReconciler struct {
 	ContextPrefix     string
 	SingleFlightGroup singleflight.Group
 	Domain            string
+	ClusterUID        string
 }
 
 const protectionIndexKey = "protection_id"
@@ -221,6 +222,11 @@ func (r *PersistentVolumeReconciler) processVolumeForReplicationGroup(ctx contex
 func (r *PersistentVolumeReconciler) createProtectionGroupAndRG(ctx context.Context, volumeHandle string, scParams map[string]string) (string, error) {
 	log := common.GetLoggerFromContext(ctx)
 	log.V(common.InfoLevel).Info("Creating protection-group anf RG")
+
+	if r.ClusterUID != "" {
+		log.V(common.InfoLevel).Info("Adding Cluster UUID to storage parameters")
+		scParams[controller.ClusterUID] = r.ClusterUID
+	}
 
 	res, err := r.ReplicationClient.CreateStorageProtectionGroup(ctx, volumeHandle, scParams)
 	if err != nil {

--- a/controllers/replication-controller/dellcsireplicationgroup_controller.go
+++ b/controllers/replication-controller/dellcsireplicationgroup_controller.go
@@ -365,8 +365,6 @@ func (r *ReplicationGroupReconciler) processSnapshotEvent(ctx context.Context, g
 		return err
 	}
 
-	log.V(common.InfoLevel).Info("Action Namespace - " + actionAnnotation.SnapshotNamespace)
-
 	if _, err := remoteClient.GetSnapshotClass(ctx, actionAnnotation.SnapshotClass); err != nil {
 		log.Error(err, "Snapshot class does not exist on remote cluster. Not creating the remote snapshots.")
 		return err
@@ -394,14 +392,14 @@ func (r *ReplicationGroupReconciler) processSnapshotEvent(ctx context.Context, g
 
 		err = remoteClient.CreateSnapshotContent(ctx, snapContent)
 		if err != nil {
-			log.Error(err, "create snapshotContent error")
+			log.Error(err, "unable to create snapshot content")
 			return err
 		}
 
 		snapshot := makeSnapshotObject(snapRef.Name, snapContent.Name, sc.ObjectMeta.Name, actionAnnotation.SnapshotNamespace)
 		err = remoteClient.CreateSnapshotObject(ctx, snapshot)
 		if err != nil {
-			log.Error(err, "create snapshot error")
+			log.Error(err, "unable to create snapshot object")
 			return err
 		}
 	}


### PR DESCRIPTION
# Description
Retrieves the cluster UID of the system that is unique between clusters at the creation of the sidecar. The intention is to provide this information to the drivers if they wish to use it in any form when creating the name of the RCG for better identification.

It is ensured that the cluster UID is only retrieved once to avoid constantly querying during reconciles.

Example:
![image](https://user-images.githubusercontent.com/7707525/219150529-9796cd31-2157-47d2-bd11-fa5d73c7b5cd.png)
In PowerFlex, cluster UID is added to the name. It is truncated to fit the limitations of the max name length.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/618 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested on multiple clusters to ensure that the cluster UID is being retrieved correctly and passed as a parameter to the driver.
