### PR TITLE
Updated kubectl version for the init image

### DIFF
--- a/Dockerfiles/Dockerfile.init
+++ b/Dockerfiles/Dockerfile.init
@@ -8,7 +8,7 @@ WORKDIR /upgrade
 COPY scripts/upgrade ./
 RUN microdnf update -y && \
     microdnf install -y shadow-utils wget && \
-    wget -v https://dl.k8s.io/release/v1.25.6/bin/linux/amd64/kubectl && \
+    wget -v https://dl.k8s.io/release/v1.25.7/bin/linux/amd64/kubectl && \
     microdnf -y remove shadow-utils wget libmetalink expat libsemanage && \
     microdnf clean all && \
     chmod +x ./kubectl && \


### PR DESCRIPTION
# Description
Fixed new Trivy scan vulnerability reported in the init image.
Updated kubectl from v1.25.6 to v1.25.7 for golang.org/x/net update.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/583 |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Performed sanity tests with the init image deployment and upgrade script (locally modified) to test different scenarios.
[init container log.txt](https://github.com/dell/csm-replication/files/10962012/init.container.log.txt)
