### PR TITLE
Added framework for DeleteLocalVolume gRPC call + synchronized delete annotation

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -219,6 +219,10 @@ var (
 	ResourceRequest string
 	// DeletionRequested annotation which will be set to the PV on the object deletion
 	DeletionRequested string
+	// SynchronizedDeletionStatus indicates what state the PV's synchronized deletion process is in
+	// requested: local PV has been issued a delete command and needs to run DeleteRemoteVolume.
+	// complete: DeleteRemoteVolume has completed. Placed on local PV by replicator sidecar, propogated to remote PV via controller.
+	SynchronizedDeletionStatus string
 	// RemotePVRetentionPolicy indicates whether to retain or delete the target PV
 	RemotePVRetentionPolicy string
 	// RemoteRGRetentionPolicy indicates whether to retain or delete the target RG
@@ -269,6 +273,7 @@ func InitLabelsAndAnnotations(domain string) {
 	CreatedBy = domain + createdBy
 	ResourceRequest = domain + resourceRequest
 	DeletionRequested = domain + deletionRequested
+	SynchronizedDeletionStatus = domain + synchronizedDeletionStatus
 	RemotePVRetentionPolicy = domain + remotePVRetentionPolicy
 	RemoteRGRetentionPolicy = domain + remoteRGRetentionPolicy
 	MigrationRequested = domain + migrateTo

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -220,8 +220,8 @@ var (
 	// DeletionRequested annotation which will be set to the PV on the object deletion
 	DeletionRequested string
 	// SynchronizedDeletionStatus indicates what state the PV's synchronized deletion process is in
-	// requested: local PV has been issued a delete command and needs to run DeleteRemoteVolume.
-	// complete: DeleteRemoteVolume has completed. Placed on local PV by replicator sidecar, propogated to remote PV via controller.
+	// requested: PV has been issued a delete command by the remote controller and needs to run DeleteLocalVolume.
+	// complete: DeleteLocalVolume has completed. Placed on PV by replicator sidecar to inform controller that deletion is done.
 	SynchronizedDeletionStatus string
 	// RemotePVRetentionPolicy indicates whether to retain or delete the target PV
 	RemotePVRetentionPolicy string

--- a/controllers/constants.go
+++ b/controllers/constants.go
@@ -87,7 +87,7 @@ const (
 	resourceRequest = "/resourceRequest"
 	// DeletionRequested annotation to set for the deleted object
 	deletionRequested = "/deletionRequested"
-	// SynchronizedDeletionStatus annotation to communicate RemoteVolumeDeletion between cluster
+	// SynchronizedDeletionStatus annotation to communicate DeleteLocalVolume call between cluster
 	synchronizedDeletionStatus = "/synchronizedDeletionStatus"
 	// Self typically used when remote cluster is same as source
 	Self = "self"

--- a/controllers/constants.go
+++ b/controllers/constants.go
@@ -87,6 +87,8 @@ const (
 	resourceRequest = "/resourceRequest"
 	// DeletionRequested annotation to set for the deleted object
 	deletionRequested = "/deletionRequested"
+	// SynchronizedDeletionStatus annotation to communicate RemoteVolumeDeletion between cluster
+	synchronizedDeletionStatus = "/synchronizedDeletionStatus"
 	// Self typically used when remote cluster is same as source
 	Self = "self"
 	// RemotePVRetentionPolicy

--- a/controllers/csi-replicator/persistentvolume_controller.go
+++ b/controllers/csi-replicator/persistentvolume_controller.go
@@ -141,18 +141,26 @@ func (r *PersistentVolumeReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}
 
+	log.V(common.DebugLevel).Info("Checking if PV protection complete annotation is applied")
+	if _, ok := pv.Annotations[controller.PVProtectionComplete]; !ok {
+		controller.AddAnnotation(pv, controller.PVProtectionComplete, "yes")
+		if err := r.Update(ctx, pv); err != nil {
+			log.Error(err, "Failed to add PV protection complete annotation to the PV")
+		}
+	}
+
 	log.V(common.DebugLevel).Info("Checking if synchronized deletion annotation is applied")
 	syncDeleteStatus, ok := pv.Annotations[controller.SynchronizedDeletionStatus]
 	if ok && syncDeleteStatus == "requested" {
 		log.V(common.InfoLevel).Info("Synchronized Deletion requested by annotation, deleting local backend volume")
 		volumeHandle := pv.Spec.PersistentVolumeSource.CSI.VolumeHandle
-		if !ok {
+		if volumeHandle == "" {
 			log.Error(err, "Failed to retrieve the PV's remote volume handle for deletion")
 			return ctrl.Result{}, err
 		}
 		_, err := r.ReplicationClient.DeleteLocalVolume(ctx, volumeHandle, storageClass.Parameters)
 		if err != nil {
-			log.Error(err, "Failed to delete the local volume", "VolumeHandle", pv.Spec.CSI.VolumeHandle)
+			log.Error(err, "Failed to delete the local volume", "VolumeHandle", pv.Spec.PersistentVolumeSource.CSI.VolumeHandle)
 			return ctrl.Result{}, err
 		}
 		pvObj := pv.DeepCopy()
@@ -161,7 +169,6 @@ func (r *PersistentVolumeReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			log.Error(err, "Failed to add SynchronizedDeletionStatus complete annotation to the PV")
 			return ctrl.Result{}, err
 		}
-		isPVUpdated = true
 	}
 
 	return ctrl.Result{}, nil

--- a/controllers/csi-replicator/persistentvolume_controller.go
+++ b/controllers/csi-replicator/persistentvolume_controller.go
@@ -155,7 +155,7 @@ func (r *PersistentVolumeReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		log.V(common.InfoLevel).Info("Synchronized Deletion requested by annotation, deleting local backend volume")
 		volumeHandle := pv.Spec.PersistentVolumeSource.CSI.VolumeHandle
 		if volumeHandle == "" {
-			log.Error(err, "Failed to retrieve the PV's remote volume handle for deletion")
+			log.Error(err, "Failed to retrieve the PV's volume handle for deletion")
 			return ctrl.Result{}, err
 		}
 		_, err := r.ReplicationClient.DeleteLocalVolume(ctx, volumeHandle, storageClass.Parameters)

--- a/controllers/replication-controller/persistentvolume_controller.go
+++ b/controllers/replication-controller/persistentvolume_controller.go
@@ -176,9 +176,9 @@ func (r *PersistentVolumeReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		if !ok || syncDeleteStatus == "complete" {
 			log.V(common.InfoLevel).Info("Synchronized Deletion annotation either complete or not set, deleting PV")
 			return ctrl.Result{}, r.Delete(ctx, volumeCopy)
-		} else {
-			log.V(common.InfoLevel).Info("Synchronized Deletion annotation exists and is not complete, cannot delete PV")
 		}
+
+		log.V(common.InfoLevel).Info("Synchronized Deletion annotation exists and is not complete, cannot delete PV")
 	}
 
 	_, ok = volume.Annotations[controller.PVProtectionComplete]

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bombsimon/logrusr/v3 v3.0.0
 	github.com/dell/dell-csi-extensions/common v1.1.1
 	github.com/dell/dell-csi-extensions/migration v1.1.0
-	github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230315203650-c10cd09b0057
+	github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230316192210-d1b46db0cbe0
 	github.com/dell/gobrick v1.4.0
 	github.com/fatih/color v1.13.0
 	github.com/fsnotify/fsnotify v1.5.4

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bombsimon/logrusr/v3 v3.0.0
 	github.com/dell/dell-csi-extensions/common v1.1.1
 	github.com/dell/dell-csi-extensions/migration v1.1.0
-	github.com/dell/dell-csi-extensions/replication v1.3.0
+	github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230315203650-c10cd09b0057
 	github.com/dell/gobrick v1.4.0
 	github.com/fatih/color v1.13.0
 	github.com/fsnotify/fsnotify v1.5.4

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,8 @@ github.com/dell/dell-csi-extensions/common v1.1.1 h1:PXdqCm6lL1g02KuR9SrsrZeoTk6
 github.com/dell/dell-csi-extensions/common v1.1.1/go.mod h1:eHfx1rwttqdPZBy8cfvRbJYPElGa/NY4fRR/P//yndw=
 github.com/dell/dell-csi-extensions/migration v1.1.0 h1:O5zmiJeEG80HVQ63SF/zah1kvH3IcIDuVq+4vmMQkhE=
 github.com/dell/dell-csi-extensions/migration v1.1.0/go.mod h1:l/KJOX0phNQDK9qJugJG81Sa/17MxN8xvSyEEympYNY=
-github.com/dell/dell-csi-extensions/replication v1.3.0 h1:Z2w+jwoyBM4ESKhABLeRjIcWxJMd4Bnt3phEPeQhljw=
-github.com/dell/dell-csi-extensions/replication v1.3.0/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
+github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230315203650-c10cd09b0057 h1:U3o1EyjtMHPnHsNLZkzzeHEgNVNfojzQZjOebVSfuNY=
+github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230315203650-c10cd09b0057/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
 github.com/dell/gobrick v1.4.0 h1:YABxiIsHLytMu92tuNqE9apPDBXD8v/RKu5go7gV5XA=
 github.com/dell/gobrick v1.4.0/go.mod h1:26AsAebGUd/FuMiQzNM6+8P0IBteipNrAaSYEMVazP8=
 github.com/dell/goiscsi v1.4.0 h1:TpMo0BLQpHsuUaePHBwZ0yjcq8gXhOOuYeUPzqmwjKk=

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,8 @@ github.com/dell/dell-csi-extensions/common v1.1.1 h1:PXdqCm6lL1g02KuR9SrsrZeoTk6
 github.com/dell/dell-csi-extensions/common v1.1.1/go.mod h1:eHfx1rwttqdPZBy8cfvRbJYPElGa/NY4fRR/P//yndw=
 github.com/dell/dell-csi-extensions/migration v1.1.0 h1:O5zmiJeEG80HVQ63SF/zah1kvH3IcIDuVq+4vmMQkhE=
 github.com/dell/dell-csi-extensions/migration v1.1.0/go.mod h1:l/KJOX0phNQDK9qJugJG81Sa/17MxN8xvSyEEympYNY=
-github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230315203650-c10cd09b0057 h1:U3o1EyjtMHPnHsNLZkzzeHEgNVNfojzQZjOebVSfuNY=
-github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230315203650-c10cd09b0057/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
+github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230316192210-d1b46db0cbe0 h1:8puwDAHQI+SI9KoKigJARxmwRE1tk40zRFekt6WQQ/o=
+github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230316192210-d1b46db0cbe0/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
 github.com/dell/gobrick v1.4.0 h1:YABxiIsHLytMu92tuNqE9apPDBXD8v/RKu5go7gV5XA=
 github.com/dell/gobrick v1.4.0/go.mod h1:26AsAebGUd/FuMiQzNM6+8P0IBteipNrAaSYEMVazP8=
 github.com/dell/goiscsi v1.4.0 h1:TpMo0BLQpHsuUaePHBwZ0yjcq8gXhOOuYeUPzqmwjKk=

--- a/pkg/csi-clients/replication/replication.go
+++ b/pkg/csi-clients/replication/replication.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2021-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import (
 // Replication is an interface that defines calls used for querying replication management calls to the driver
 type Replication interface {
 	CreateRemoteVolume(context.Context, string, map[string]string) (*csiext.CreateRemoteVolumeResponse, error)
+	DeleteLocalVolume(context.Context, string, map[string]string) (*csiext.DeleteLocalVolumeResponse, error)
 	CreateStorageProtectionGroup(context.Context, string, map[string]string) (*csiext.CreateStorageProtectionGroupResponse, error)
 	DeleteStorageProtectionGroup(context.Context, string, map[string]string) error
 	ExecuteAction(context.Context, string, *csiext.ExecuteActionRequest_Action, map[string]string, string, map[string]string) (*csiext.ExecuteActionResponse, error)
@@ -112,6 +113,18 @@ func (r *replication) CreateRemoteVolume(ctx context.Context, volumeHandle strin
 	}
 
 	res, err := client.CreateRemoteVolume(tctx, req)
+	return res, err
+}
+
+// DeleteLocalVolume sends deletion request of a specified volumeHandle
+func (r *replication) DeleteLocalVolume(ctx context.Context, volumeHandle string, params map[string]string) (*csiext.DeleteLocalVolumeResponse, error) {
+	tctx, cancel := context.WithTimeout(ctx, r.timeout)
+	defer cancel()
+	client := csiext.NewReplicationClient(r.conn)
+
+	req := &csiext.DeleteLocalVolumeRequest{}
+
+	res, err := client.DeleteLocalVolume(tctx, req)
 	return res, err
 }
 

--- a/pkg/csi-clients/replication/replication.go
+++ b/pkg/csi-clients/replication/replication.go
@@ -122,7 +122,10 @@ func (r *replication) DeleteLocalVolume(ctx context.Context, volumeHandle string
 	defer cancel()
 	client := csiext.NewReplicationClient(r.conn)
 
-	req := &csiext.DeleteLocalVolumeRequest{}
+	req := &csiext.DeleteLocalVolumeRequest{
+		VolumeHandle:     volumeHandle,
+		VolumeAttributes: params,
+	}
 
 	res, err := client.DeleteLocalVolume(tctx, req)
 	return res, err

--- a/pkg/csi-clients/replication/replication_fake.go
+++ b/pkg/csi-clients/replication/replication_fake.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2021-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -153,6 +153,26 @@ func (m *MockReplication) CreateRemoteVolume(ctx context.Context, volumeHandle s
 	volParams[path.Join(m.contextPrefix, "arrayParam2")] = "arrayVal2"
 	response := csiext.CreateRemoteVolumeResponse{
 		RemoteVolume: &csiext.Volume{
+			CapacityBytes: 1024 * 1024 * 1024,
+			VolumeId:      fmt.Sprintf("remote-%s-fake-volume", volumeHandle),
+			VolumeContext: volParams,
+		},
+	}
+	return &response, nil
+}
+
+// DeleteLocalVolume mocks call
+func (m *MockReplication) DeleteLocalVolume(ctx context.Context, volumeHandle string,
+	params map[string]string) (*csiext.DeleteLocalVolumeResponse, error) {
+	defer m.ClearErrorAndCondition(false)
+	if err := m.injectedError.getError(); err != nil {
+		return nil, err
+	}
+	volParams := params
+	volParams[path.Join(m.contextPrefix, "arrayParam1")] = "arrayVal1"
+	volParams[path.Join(m.contextPrefix, "arrayParam2")] = "arrayVal2"
+	response := csiext.DeleteLocalVolumeResponse{
+		LocalVolume: &csiext.Volume{
 			CapacityBytes: 1024 * 1024 * 1024,
 			VolumeId:      fmt.Sprintf("remote-%s-fake-volume", volumeHandle),
 			VolumeContext: volParams,

--- a/pkg/csi-clients/replication/replication_fake.go
+++ b/pkg/csi-clients/replication/replication_fake.go
@@ -168,16 +168,7 @@ func (m *MockReplication) DeleteLocalVolume(ctx context.Context, volumeHandle st
 	if err := m.injectedError.getError(); err != nil {
 		return nil, err
 	}
-	volParams := params
-	volParams[path.Join(m.contextPrefix, "arrayParam1")] = "arrayVal1"
-	volParams[path.Join(m.contextPrefix, "arrayParam2")] = "arrayVal2"
-	response := csiext.DeleteLocalVolumeResponse{
-		LocalVolume: &csiext.Volume{
-			CapacityBytes: 1024 * 1024 * 1024,
-			VolumeId:      fmt.Sprintf("remote-%s-fake-volume", volumeHandle),
-			VolumeContext: volParams,
-		},
-	}
+	response := csiext.DeleteLocalVolumeResponse{}
 	return &response, nil
 }
 

--- a/test/mock-server/server/server.go
+++ b/test/mock-server/server/server.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2021-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/test/mock-server/server/server.go
+++ b/test/mock-server/server/server.go
@@ -130,6 +130,13 @@ func (s *Replication) CreateRemoteVolume(ctx context.Context, in *replication.Cr
 	return out, err
 }
 
+// DeleteLocalVolume calls stub for DeleteLocalVolume
+func (s *Replication) DeleteLocalVolume(ctx context.Context, in *replication.DeleteLocalVolumeRequest) (*replication.DeleteLocalVolumeResponse, error) {
+	out := &replication.DeleteLocalVolumeResponse{}
+	err := FindStub("Replication", "DeleteLocalVolume", in, out)
+	return out, err
+}
+
 // DeleteStorageProtectionGroup calls stub for DeleteStorageProtectionGroup
 func (s *Replication) DeleteStorageProtectionGroup(ctx context.Context, in *replication.DeleteStorageProtectionGroupRequest) (*replication.DeleteStorageProtectionGroupResponse, error) {
 	out := &replication.DeleteStorageProtectionGroupResponse{}


### PR DESCRIPTION
# Description
New annotation for synchronized deletion of backend volumes has been added, and logic to support this and a new gRPC call in the replicator sidecar (DeleteLocalVolume) have been added as well. 

Driver-level implementation of DeleteLocalVolume to follow. PR is set as draft for now.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| [665](https://github.com/dell/csm/issues/665) |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Usage of the new gRPC call and annotation has been tested with the PowerStore CSI driver. Annotations were applied and edited as expected, and remote PVs were deleted as expected. 