### PR TITLE
PowerStore file support added to repctl

### DIFF
--- a/repctl/examples/powerstore_block_example_values.yaml
+++ b/repctl/examples/powerstore_block_example_values.yaml
@@ -1,0 +1,20 @@
+sourceClusterID: "cluster-1"
+targetClusterID: "cluster-2"
+name: "powerstore-replication"
+driver: "powerstore"
+reclaimPolicy: "Retain"
+replicationPrefix: "replication.storage.dell.com"
+remoteRetentionPolicy:
+  RG: "Retain"
+  PV: "Retain"
+parameters:
+  fsType: ext4
+  arrayID: # populate with unique ids of storage arrays
+    source: "PS000000000001"
+    target: "PS000000000002"
+  remoteSystem: # populate with name of the remote system as seen from the current PowerStore instance
+    source: "RT-A0001"
+    target: "RT-A0002"
+  rpo: "Five_Minutes"
+  ignoreNamespaces: "false"
+  volumeGroupPrefix: "csi"

--- a/repctl/examples/powerstore_file_example_values.yaml
+++ b/repctl/examples/powerstore_file_example_values.yaml
@@ -1,6 +1,6 @@
 sourceClusterID: "cluster-1"
 targetClusterID: "cluster-2"
-name: "powerstore-replication"
+name: "powerstore-replication-nfs"
 driver: "powerstore"
 reclaimPolicy: "Retain"
 replicationPrefix: "replication.storage.dell.com"
@@ -8,6 +8,7 @@ remoteRetentionPolicy:
   RG: "Retain"
   PV: "Retain"
 parameters:
+  fsType: nfs 
   arrayID: # populate with unique ids of storage arrays
     source: "PS000000000001"
     target: "PS000000000002"
@@ -17,3 +18,5 @@ parameters:
   rpo: "Five_Minutes"
   ignoreNamespaces: "false"
   volumeGroupPrefix: "csi"
+  NasName: "NAS-1" # populate with the name of the NAS server that the file system will be placed on
+  allowRoot: "false" 

--- a/repctl/pkg/cmd/create.go
+++ b/repctl/pkg/cmd/create.go
@@ -48,10 +48,13 @@ type Mirrored struct {
 type GlobalParameters struct {
 	// PowerStore
 	ArrayID           Mirrored
+	FsType            string
 	RemoteSystem      Mirrored
 	Rpo               string
 	IgnoreNamespaces  bool
 	VolumeGroupPrefix string
+	NasName           string
+	AllowRoot         bool
 
 	// PowerMax
 	Srp          Mirrored

--- a/repctl/pkg/cmd/templates/powerstore_source.yaml
+++ b/repctl/pkg/cmd/templates/powerstore_source.yaml
@@ -6,6 +6,13 @@ provisioner: csi-{{ .Driver }}.dellemc.com
 reclaimPolicy: {{ .ReclaimPolicy }}
 volumeBindingMode: Immediate
 parameters:
+  {{- if .Parameters.FsType }}
+  csi.storage.k8s.io/fstype: {{ .Parameters.FsType }}
+  {{- if eq .Parameters.FsType "nfs"}}
+  {{ .ReplicationPrefix }}/nasName: "{{ .Parameters.NasName }}"
+  {{ .ReplicationPrefix }}/allowRoot: "{{ .Parameters.AllowRoot }}"
+  {{- end }}
+  {{- end }}
   {{ .ReplicationPrefix }}/isReplicationEnabled: "true"
   {{- if eq .TargetClusterID .SourceClusterID }}
   {{ .ReplicationPrefix }}/remoteStorageClassName: {{ .Name }}-tgt

--- a/repctl/pkg/cmd/templates/powerstore_target.yaml
+++ b/repctl/pkg/cmd/templates/powerstore_target.yaml
@@ -10,6 +10,13 @@ provisioner: csi-{{ .Driver }}.dellemc.com
 reclaimPolicy: {{ .ReclaimPolicy }}
 volumeBindingMode: Immediate
 parameters:
+  {{- if .Parameters.FsType }}
+  csi.storage.k8s.io/fstype: {{ .Parameters.FsType }}
+  {{- if eq .Parameters.FsType "nfs"}}
+  {{ .ReplicationPrefix }}/nasName: "{{ .Parameters.NasName }}"
+  {{ .ReplicationPrefix }}/allowRoot: "{{ .Parameters.AllowRoot }}"
+  {{- end }}
+  {{- end }}
   {{ .ReplicationPrefix }}/isReplicationEnabled: "true"
   {{ .ReplicationPrefix }}/remoteStorageClassName: {{ .Name }}
   {{- if eq .TargetClusterID .SourceClusterID }}


### PR DESCRIPTION
# Description
A few sentences describing the overall goals of the pull request's commits.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| [639](https://github.com/dell/csm/issues/639) |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Repctl has been rebuilt and used to generate storage classes for both block and file PowerStore replication. 
