### PR TITLE
Add determination of valid command for kubeconfig generation

### DIFF
--- a/.github/containerscan/allowedlist.yaml
+++ b/.github/containerscan/allowedlist.yaml
@@ -1,3 +1,4 @@
 general:
   vulnerabilities:
     - CVE-2019-1010022 # "Will not fix", see https://access.redhat.com/security/cve/CVE-2019-1010022
+    - CVE-2023-2253

--- a/scripts/gen_kubeconfig.sh
+++ b/scripts/gen_kubeconfig.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ######################################################################
-# Copyright © 2021 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ if [ -x "$(command -v kubectl)" ]; then
 elif [ -x "$(command -v oc)" ]; then
   cmd='oc'
 else
-  echo "Neither kubectl or oc are not installed. Verify setup"
+  echo "Neither kubectl nor oc are not installed. Verify setup."
   exit 1
 fi
 

--- a/scripts/gen_kubeconfig.sh
+++ b/scripts/gen_kubeconfig.sh
@@ -13,6 +13,16 @@
 # limitations under the License.
 ######################################################################
 
+# Determine the command to use.
+if [ -x "$(command -v kubectl)" ]; then
+  cmd='kubectl'
+elif [ -x "$(command -v oc)" ]; then
+  cmd='oc'
+else
+  echo "Neither kubectl or oc are not installed. Verify setup"
+  exit 1
+fi
+
 #######################################
 # Prints formatted command's action
 # Arguments:
@@ -69,15 +79,17 @@ function service_branch() {
   if [ -z "${o}" ]; then
     output="./configs/config-$s"
   fi
+  
   t_print_action "Compiling kubeconfig for \"$s\"" && t_print_status
+  echo "Namespace: $ns, cmd: "
   t_print_action "Extracting secret"
-  gnsecret=$(kubectl -n $ns describe sa $s 2>/dev/null | grep Mountable | awk '{print $3}') && t_print_status || finish_error
+  gnsecret=$($cmd -n $ns describe sa $s 2>/dev/null | grep Mountable | awk '{print $3}') && t_print_status || finish_error
   t_print_action "Extracting token"
-  gntoken=$(kubectl -n $ns describe secret $gnsecret | grep token: | awk '{print $2}') && t_print_status || finish_error
+  gntoken=$($cmd -n $ns describe secret $gnsecret | grep token: | awk '{print $2}') && t_print_status || finish_error
   t_print_action "Extracting CA"
-  gncert=$(kubectl config view --flatten --minify | grep certificate-authority-data: | awk '{print $2}') && t_print_status || finish_error
+  gncert=$($cmd config view --flatten --minify | grep certificate-authority-data: | awk '{print $2}') && t_print_status || finish_error
   t_print_action "Extracting server URL"
-  gnserver=$(kubectl config view --flatten --minify | grep server: | awk '{print $2}') && t_print_status || finish_error
+  gnserver=$($cmd config view --flatten --minify | grep server: | awk '{print $2}') && t_print_status || finish_error
 
   export gnsecret
   export gntoken
@@ -107,40 +119,42 @@ function user_branch() {
   if [ -z "${c}" ] || [ -z "${k}" ]; then
     usage
   fi
+
   if [ -z "${o}" ]; then
     output="./configs/config-$u"
   fi
+
   t_print_action "Encoding and applying CSR.. "
   export base64_csr=$(cat $c | base64 | tr -d '\n')
   export certname=$u
-  cat csr.yaml | envsubst | kubectl apply -f - &>/dev/null && t_print_status || finish_error
+  cat csr.yaml | envsubst | $cmd apply -f - &>/dev/null && t_print_status || finish_error
 
   t_print_action "Approving CSR.. "
-  kubectl certificate approve $u &>/dev/null && t_print_status || finish_error
+  $cmd certificate approve $u &>/dev/null && t_print_status || finish_error
 
   t_print_action "CSR Status: "
-  t_print_status "$(kubectl get csr | grep $u | awk '{print $5}')"
+  t_print_status "$($cmd get csr | grep $u | awk '{print $5}')"
 
   t_print_action "Saving cert.. "
-  kubectl get csr $u -o jsonpath='{.status.certificate}' | base64 --decode >./tmp/$u.crt && t_print_status || finish_error
+  $cmd get csr $u -o jsonpath='{.status.certificate}' | base64 --decode >./tmp/$u.crt && t_print_status || finish_error
 
   t_print_action "Using name \"$u\".. "
   t_print_status
 
   t_print_action "Saving temp CA cert.. "
-  kubectl config view -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' --raw | base64 --decode - >./tmp/kubernetes-ca.crt && t_print_status || finish_error
+  $cmd config view -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' --raw | base64 --decode - >./tmp/kubernetes-ca.crt && t_print_status || finish_error
 
   t_print_action "Creating kubeconfig for \"$u\".. "
-  kubectl config set-cluster $(kubectl config view -o jsonpath='{.clusters[0].name}') --server=$(kubectl config view -o jsonpath='{.clusters[0].cluster.server}') --certificate-authority=./tmp/kubernetes-ca.crt --kubeconfig=$output --embed-certs &>/dev/null && t_print_status || finish_error
+  $cmd config set-cluster $($cmd config view -o jsonpath='{.clusters[0].name}') --server=$($cmd config view -o jsonpath='{.clusters[0].cluster.server}') --certificate-authority=./tmp/kubernetes-ca.crt --kubeconfig=$output --embed-certs &>/dev/null && t_print_status || finish_error
 
   t_print_action "Setting credentials.. "
-  kubectl config set-credentials $u --client-certificate=./tmp/$u.crt --client-key=$k --embed-certs --kubeconfig=$output &>/dev/null && t_print_status || finish_error
+  $cmd config set-credentials $u --client-certificate=./tmp/$u.crt --client-key=$k --embed-certs --kubeconfig=$output &>/dev/null && t_print_status || finish_error
 
   t_print_action "Setting context.. "
-  kubectl config set-context $u --cluster=$(kubectl config view -o jsonpath='{.clusters[0].name}') --namespace=default --user=$u --kubeconfig=$output &>/dev/null && t_print_status || finish_error
+  $cmd config set-context $u --cluster=$($cmd config view -o jsonpath='{.clusters[0].name}') --namespace=default --user=$u --kubeconfig=$output &>/dev/null && t_print_status || finish_error
 
   t_print_action "Applying context.. "
-  kubectl config use-context $u --kubeconfig=$output &>/dev/null && t_print_status || finish_error
+  $cmd config use-context $u --kubeconfig=$output &>/dev/null && t_print_status || finish_error
   echo "DONE. Kubeconfig location: $output"
 }
 

--- a/scripts/gen_kubeconfig.sh
+++ b/scripts/gen_kubeconfig.sh
@@ -19,7 +19,7 @@ if [ -x "$(command -v kubectl)" ]; then
 elif [ -x "$(command -v oc)" ]; then
   cmd='oc'
 else
-  echo "Neither kubectl nor oc are not installed. Verify setup."
+  echo "Neither kubectl nor oc is installed. Verify setup."
   exit 1
 fi
 


### PR DESCRIPTION
# Description
Determine the existence of `kubectl` and `oc` commands. If the `oc` command is present, use that for extracting the service accounts and generating the kubeconfigs.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/815 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested on an OpenShift 4.11 cluster to ensure that the kubeconfigs are generated accordingly.

![image](https://github.com/dell/csm-replication/assets/7707525/2decac5d-c681-4cab-af6b-ff81405daaf3)
