### PR TITLE
Repctl: Set migration namespace only when it is provided

### DIFF
--- a/repctl/pkg/cmd/migrate.go
+++ b/repctl/pkg/cmd/migrate.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2022-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -341,7 +341,9 @@ func migratePV(ctx context.Context, cluster k8s.ClusterInterface, pvName string,
 	}
 	log.Infof("Setting migration annotation %s on pv %s", migrationAnnotation+"/"+toSC, pv.Name)
 	pv.Annotations[migrationAnnotation] = toSC
-	pv.Annotations[migrationNS] = targetNS
+	if len(targetNS) > 0 {
+		pv.Annotations[migrationNS] = targetNS
+	}
 	err = cluster.UpdatePersistentVolume(context.Background(), pv)
 	if err != nil {
 		log.Error(err, "unable to update persistent volume")


### PR DESCRIPTION
# Description
Repctl migrate cmd: Set migration namespace only when it is provided in the optional _target-ns_ parameter.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/841 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Ran ./repctl migrate cmd with and without _target-ns_ parameter and it worked. Thanks @boyamurthy for testing.