### PR TITLE
Updated kubectl version for the init image

### DIFF
--- a/Dockerfiles/Dockerfile.init
+++ b/Dockerfiles/Dockerfile.init
@@ -5,7 +5,7 @@ ARG BASEIMAGE
 
 FROM golang:1.20 AS builder
 WORKDIR /build
-RUN wget https://dl.k8s.io/release/v1.26.5/bin/linux/amd64/kubectl -O kubectl
+RUN wget https://dl.k8s.io/release/v1.26.6/bin/linux/amd64/kubectl -O kubectl
 
 FROM $BASEIMAGE AS init
 WORKDIR /upgrade


### PR DESCRIPTION
# Description
Updated kubectl version used in the init container image for fixing security vulnerabilities.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/743 |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?

Verified the init container log for cases when it does not perform CRD upgrade and when it performs the upgrade (altered the script for quick testing).
Scanned the new image and noticed that the vulnerabilities are no longer reported.
![init-with-kubectl-1 26 6](https://github.com/dell/csm-replication/assets/111809751/a5bc2958-e96c-41fa-8171-fd24d412c706)
![init-with-kubectl-1 26 6-migration induced](https://github.com/dell/csm-replication/assets/111809751/44b99e40-90f7-4de1-ac51-dec76df5006b)
