### PR TITLE
Updated kubectl to v1.26.6 (#101)

### DIFF
--- a/Dockerfiles/Dockerfile.init
+++ b/Dockerfiles/Dockerfile.init
@@ -5,7 +5,7 @@ ARG BASEIMAGE
 
 FROM golang:1.20 AS builder
 WORKDIR /build
-RUN wget https://dl.k8s.io/release/v1.26.5/bin/linux/amd64/kubectl -O kubectl
+RUN wget https://dl.k8s.io/release/v1.26.6/bin/linux/amd64/kubectl -O kubectl
 
 FROM $BASEIMAGE AS init
 WORKDIR /upgrade


### PR DESCRIPTION
# Description
Updated kubectl version used in the init container image for fixing security vulnerabilities. Merging Code of release branch with main. Refer the pull request for more details https://github.com/dell/csm-replication/pull/101

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/743|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes

