### PR TITLE
Helm install script update, golangci-lint fixes and controller version update to 1.6.0 for repctl

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -26,5 +26,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.53
+          version: v1.54
           skip-cache: true

--- a/cmd/csi-migrator/main.go
+++ b/cmd/csi-migrator/main.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2022-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/cmd/csi-migrator/main.go
+++ b/cmd/csi-migrator/main.go
@@ -19,6 +19,9 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"os"
+	"strings"
+	"time"
 
 	"github.com/dell/dell-csi-extensions/migration"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -29,10 +32,6 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
-
-	"os"
-	"strings"
-	"time"
 
 	storagev1 "github.com/dell/csm-replication/api/v1"
 	"github.com/dell/csm-replication/controllers"
@@ -90,7 +89,6 @@ func (mgr *MigratorManager) processConfigMapChanges(loggerConfig *logrus.Logger)
 	}
 	log.Println("set level to", level)
 	loggerConfig.SetLevel(level)
-
 }
 
 func (mgr *MigratorManager) setupConfigMapWatcher(loggerConfig *logrus.Logger) {
@@ -260,5 +258,4 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
-
 }

--- a/cmd/csi-node-rescanner/main.go
+++ b/cmd/csi-node-rescanner/main.go
@@ -85,7 +85,6 @@ func (mgr *NodeRescanner) processConfigMapChanges(loggerConfig *logrus.Logger) {
 	}
 	log.Println("set level to", level)
 	loggerConfig.SetLevel(level)
-
 }
 
 func (mgr *NodeRescanner) setupConfigMapWatcher(loggerConfig *logrus.Logger) {
@@ -213,7 +212,7 @@ func main() {
 	}
 	log.Printf("Rescan manager configured: (+%v)", rescanMgr)
 	// Start the watch on configmap
-	//rescanMgr.setupConfigMapWatcher(logrusLog)
+	// rescanMgr.setupConfigMapWatcher(logrusLog)
 
 	// Process the config. Get initial log level
 	level, err := common.ParseLevel("debug")
@@ -243,5 +242,4 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
-
 }

--- a/cmd/csi-node-rescanner/main.go
+++ b/cmd/csi-node-rescanner/main.go
@@ -95,7 +95,7 @@ func (mgr *NodeRescanner) setupConfigMapWatcher(loggerConfig *logrus.Logger) {
 	})
 }
 
-func createNodeReScannerManager(ctx context.Context, mgr ctrl.Manager) (*NodeRescanner, error) {
+func createNodeReScannerManager(_ context.Context, mgr ctrl.Manager) (*NodeRescanner, error) {
 	opts := config.GetControllerManagerOpts()
 	opts.Mode = "sidecar"
 	//mgrLogger := mgr.GetLogger()

--- a/cmd/csi-replicator/main.go
+++ b/cmd/csi-replicator/main.go
@@ -19,16 +19,15 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"os"
+	"strings"
+	"time"
 
 	"github.com/bombsimon/logrusr/v4"
 	"github.com/dell/csm-replication/pkg/config"
 	"github.com/fsnotify/fsnotify"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
-
-	"os"
-	"strings"
-	"time"
 
 	"github.com/dell/csm-replication/controllers"
 	"github.com/dell/csm-replication/pkg/common"
@@ -92,7 +91,6 @@ func (mgr *ReplicatorManager) processConfigMapChanges(loggerConfig *logrus.Logge
 	}
 	log.Println("set level to", level)
 	loggerConfig.SetLevel(level)
-
 }
 
 func (mgr *ReplicatorManager) setupConfigMapWatcher(loggerConfig *logrus.Logger) {
@@ -311,7 +309,6 @@ func main() {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}
-
 }
 
 func getClusterUID(ctx context.Context) (*v1.Namespace, error) {

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -21,7 +21,7 @@ spec:
         args:
         - --enable-leader-election
         - --prefix=replication.storage.dell.com
-        image: dellemc/dell-replication-controller:v1.5.0
+        image: dellemc/dell-replication-controller:v1.6.0
         imagePullPolicy: Always
         name: manager
         env:

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -16,7 +16,6 @@ package controllers
 
 import (
 	"context"
-
 	"os"
 
 	repv1 "github.com/dell/csm-replication/api/v1"

--- a/controllers/csi-migrator/dellcsimigrationgroup_controller.go
+++ b/controllers/csi-migrator/dellcsimigrationgroup_controller.go
@@ -279,7 +279,7 @@ func (r *MigrationGroupReconciler) updateMGSpecWithState(ctx context.Context, mg
 }
 
 // Update mg on error
-func (r *MigrationGroupReconciler) updateMGOnError(ctx context.Context, mg *storagev1.DellCSIMigrationGroup, currentState string, CurrentAction string) error {
+func (r *MigrationGroupReconciler) updateMGOnError(ctx context.Context, mg *storagev1.DellCSIMigrationGroup, currentState string, _ string) error {
 	log := common.GetLoggerFromContext(ctx)
 	log.V(common.InfoLevel).Info("Begin updating MG status with", "ErrorState", ErrorState)
 	mg.Status.LastAction = currentState
@@ -288,10 +288,7 @@ func (r *MigrationGroupReconciler) updateMGOnError(ctx context.Context, mg *stor
 			"Action [%s] on DellCSIMigrationGroup [%s] failed with error ",
 			CurrentAction, mg.Name)
 	*/
-	if err := r.updateMGSpecWithState(ctx, mg.DeepCopy(), ErrorState); err != nil {
-		return err
-	}
-	return nil
+	return r.updateMGSpecWithState(ctx, mg.DeepCopy(), ErrorState)
 }
 
 // Update mg with annotation

--- a/controllers/csi-migrator/dellcsimigrationgroup_controller.go
+++ b/controllers/csi-migrator/dellcsimigrationgroup_controller.go
@@ -56,7 +56,7 @@ const (
 	CommittedState = "Committed"
 	// DeletingState name deletion state of MigrationGroup
 	DeletingState = "Deleting"
-	//ArrayMigrationState key used to annotate MigrationGroup CR through ArrayMigration phases
+	// ArrayMigrationState key used to annotate MigrationGroup CR through ArrayMigration phases
 	ArrayMigrationState = "ArrayMigrate"
 	// MaxRetryDurationForActions maximum amount of time between retries of failed action
 	MaxRetryDurationForActions = 1 * time.Hour
@@ -121,7 +121,7 @@ func (r *MigrationGroupReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return r.processMGForDeletion(ctx, mg.DeepCopy())
 	}
 	if !mg.DeletionTimestamp.IsZero() {
-		//If MG in migrating state; TODO - cancel migration state
+		// If MG in migrating state; TODO - cancel migration state
 		err := fmt.Errorf("MG is not ready for deletion; If you want to cancel migration, please follow manual steps")
 		return ctrl.Result{}, err
 	}
@@ -198,7 +198,7 @@ func (r *MigrationGroupReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	} else if (NextAnnotationAction == "Migrate") || (NextAnnotationAction == "Commit") {
 
-		//Include format and config validation on the driver side
+		// Include format and config validation on the driver side
 		ArrayMigrateReqParams := map[string]string{
 			"DriverName":     mg.Spec.DriverName,
 			SymmetrixIDParam: mg.Spec.SourceID,
@@ -226,17 +226,17 @@ func (r *MigrationGroupReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			log.V(common.InfoLevel).Info("Successfully executed action [%s]", CurrentAction.String())
 		}
 	} else if NextAnnotationAction == "Delete" {
-		//reset NodesToRescan
+		// reset NodesToRescan
 		NodesToRescan.AllSynced = false
 	}
-	//update lastAction to current state
+	// update lastAction to current state
 	mg.Status.LastAction = currentState
 
-	//update state field of the mg
+	// update state field of the mg
 	if err := r.updateMGSpecWithState(ctx, mg.DeepCopy(), NextState); err != nil {
 		return ctrl.Result{}, err
 	}
-	//update annotation
+	// update annotation
 	isSpecUpdated := r.updateMGSpecWithActionResult(ctx, mg, NextAnnotationAction)
 	if isSpecUpdated {
 		if err := r.Client.Update(ctx, mg.DeepCopy()); err != nil {
@@ -349,7 +349,7 @@ func (r *MigrationGroupReconciler) addFinalizer(ctx context.Context, mg *storage
 
 // processing for deletion
 func (r *MigrationGroupReconciler) processMGForDeletion(ctx context.Context, dellCSIMigrationGroup *storagev1.DellCSIMigrationGroup) (ctrl.Result, error) {
-	//log := common.GetLoggerFromContext(ctx)
+	// log := common.GetLoggerFromContext(ctx)
 	if dellCSIMigrationGroup.Status.State != DeletingState {
 		err := r.updateMGSpecWithState(ctx, dellCSIMigrationGroup.DeepCopy(), DeletingState)
 		return ctrl.Result{}, err
@@ -367,7 +367,7 @@ func (r *MigrationGroupReconciler) removeFinalizer(ctx context.Context, mg *stor
 	// Remove migration group finalizer
 	if ok := controllers.RemoveFinalizerIfExists(mg, controllers.MigrationFinalizer); ok {
 		// Adding annotation to mark the removal of protection-group
-		//controllers.AddAnnotation(mg, controllers.MigrationGroupRemovedAnnotation, "yes")
+		// controllers.AddAnnotation(mg, controllers.MigrationGroupRemovedAnnotation, "yes")
 		if err := r.Update(ctx, mg.DeepCopy()); err != nil {
 			log.Error(err, "Failed to remove finalizer", "mg", mg, "MigrationGroupRemovedAnnotation")
 			return err

--- a/controllers/csi-migrator/dellcsimigrationgroup_controller_test.go
+++ b/controllers/csi-migrator/dellcsimigrationgroup_controller_test.go
@@ -18,9 +18,10 @@ package csimigrator
 
 import (
 	"context"
-	csimigration "github.com/dell/csm-replication/pkg/csi-clients/migration"
 	"testing"
 	"time"
+
+	csimigration "github.com/dell/csm-replication/pkg/csi-clients/migration"
 
 	storagev1 "github.com/dell/csm-replication/api/v1"
 	"github.com/dell/csm-replication/controllers"
@@ -153,7 +154,6 @@ func (suite *MGControllerTestSuite) TestMGReconcileWithMigratedState() {
 	err = suite.client.Get(ctx, types.NamespacedName{Namespace: "", Name: mg1.Name}, mg)
 	suite.NoError(err, "No error on MG get")
 	suite.Equal(CommitReadyState, mg.Status.State, "State should be Ready")
-
 }
 
 // MG with CommitReadyState
@@ -185,7 +185,6 @@ func (suite *MGControllerTestSuite) TestMGReconcileWithCommitReadyState() {
 	suite.NoError(err, "No error on MG get")
 	suite.Equal(CommittedState, mg.Status.State, "State should be Ready")
 	suite.Equal(CommitReadyState, mg.Status.LastAction, "State should be Ready")
-
 }
 
 // MG with CommittedState
@@ -440,7 +439,6 @@ func (suite *MGControllerTestSuite) TestMGReconcileWithInvalidState() {
 	mg := new(storagev1.DellCSIMigrationGroup)
 	err = suite.client.Get(ctx, types.NamespacedName{Namespace: "", Name: mg1.Name}, mg)
 	suite.NoError(err, "No error on MG reconcile")
-
 }
 
 func (suite *MGControllerTestSuite) getTypicalReconcileRequest(name string) reconcile.Request {

--- a/controllers/csi-migrator/persistentvolume_controller.go
+++ b/controllers/csi-migrator/persistentvolume_controller.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2022-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -204,7 +204,7 @@ func bytesToQuantity(bytes int64) resource.Quantity {
 }
 
 // SetupWithManager start using reconciler by creating new controller managed by provided manager
-func (r *PersistentVolumeReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, limiter ratelimiter.RateLimiter, maxReconcilers int) error {
+func (r *PersistentVolumeReconciler) SetupWithManager(_ context.Context, mgr ctrl.Manager, limiter ratelimiter.RateLimiter, maxReconcilers int) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1.PersistentVolume{}, builder.WithPredicates(
 			predicate.Or(

--- a/controllers/csi-migrator/persistentvolume_controller.go
+++ b/controllers/csi-migrator/persistentvolume_controller.go
@@ -165,7 +165,8 @@ func (r *PersistentVolumeReconciler) Reconcile(ctx context.Context, req ctrl.Req
 				StorageClassName:              targetStorageClassName,
 				AccessModes:                   pv.Spec.AccessModes,
 				MountOptions:                  pv.Spec.MountOptions,
-				Capacity:                      v1.ResourceList{v1.ResourceStorage: bytesToQuantity(migrate.GetMigratedVolume().CapacityBytes)}},
+				Capacity:                      v1.ResourceList{v1.ResourceStorage: bytesToQuantity(migrate.GetMigratedVolume().CapacityBytes)},
+			},
 		}
 		log.V(common.InfoLevel).Info("trying to create migrated PV")
 		err = r.Create(ctx, pvT, &client.CreateOptions{})
@@ -187,7 +188,6 @@ func (r *PersistentVolumeReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	r.EventRecorder.Eventf(pv, "Normal", "Migrated", "This PV has been successfully migrated to SC %s,"+
 		" consider using new PV %s.", targetStorageClassName, pv.Name+"-to-"+targetStorageClassName)
 	return ctrl.Result{}, nil
-
 }
 
 func isMigrationRequested() predicate.Predicate {

--- a/controllers/csi-migrator/persistentvolume_controller_test.go
+++ b/controllers/csi-migrator/persistentvolume_controller_test.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2022-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -732,7 +732,7 @@ type errorFakeCtrlRuntimeClient struct {
 	key    string
 }
 
-func (e errorFakeCtrlRuntimeClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+func (e errorFakeCtrlRuntimeClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
 	if e.method == "get" && key.Name == e.key {
 		return fmt.Errorf("Get method error")
 	}

--- a/controllers/csi-migrator/persistentvolume_controller_test.go
+++ b/controllers/csi-migrator/persistentvolume_controller_test.go
@@ -79,7 +79,7 @@ func (suite *PersistentVolumeControllerTestSuite) initReconciler() {
 }
 
 func (suite *PersistentVolumeControllerTestSuite) TestPVReconcile() {
-	//positive test
+	// positive test
 	sc1 := &storagev1.StorageClass{
 		ObjectMeta:  metav1.ObjectMeta{Name: "sc1"},
 		Provisioner: "provisionerName",
@@ -131,7 +131,7 @@ func (suite *PersistentVolumeControllerTestSuite) TestPVReconcile() {
 }
 
 func (suite *PersistentVolumeControllerTestSuite) TestPVReconcileGetPV() {
-	//pv not added to client
+	// pv not added to client
 	pv := &corev1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "pv",
@@ -162,7 +162,7 @@ func (suite *PersistentVolumeControllerTestSuite) TestPVReconcileGetPV() {
 }
 
 func (suite *PersistentVolumeControllerTestSuite) TestPVReconcileScNotFound() {
-	//specified in pv sc doesn't exist => not found
+	// specified in pv sc doesn't exist => not found
 	pv := &corev1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "pv",
@@ -197,7 +197,7 @@ func (suite *PersistentVolumeControllerTestSuite) TestPVReconcileScNotFound() {
 }
 
 func (suite *PersistentVolumeControllerTestSuite) TestPVReconcileScFailedFetch() {
-	//specified in pv sc doesn't fetch
+	// specified in pv sc doesn't fetch
 	sc1 := &storagev1.StorageClass{
 		ObjectMeta:  metav1.ObjectMeta{Name: "sc1"},
 		Provisioner: "provisionerName",
@@ -243,7 +243,7 @@ func (suite *PersistentVolumeControllerTestSuite) TestPVReconcileScFailedFetch()
 }
 
 func (suite *PersistentVolumeControllerTestSuite) TestPVReconcileGetTargetSc() {
-	//target sc2 doesn't exist => not found
+	// target sc2 doesn't exist => not found
 	sc1 := &storagev1.StorageClass{
 		ObjectMeta:  metav1.ObjectMeta{Name: "sc1"},
 		Provisioner: "provisionerName",
@@ -285,7 +285,7 @@ func (suite *PersistentVolumeControllerTestSuite) TestPVReconcileGetTargetSc() {
 }
 
 func (suite *PersistentVolumeControllerTestSuite) TestPVReconcileTargetScFailedFetch() {
-	//target sc doesn't fetch
+	// target sc doesn't fetch
 	sc1 := &storagev1.StorageClass{
 		ObjectMeta:  metav1.ObjectMeta{Name: "sc1"},
 		Provisioner: "provisionerName",
@@ -337,7 +337,7 @@ func (suite *PersistentVolumeControllerTestSuite) TestPVReconcileTargetScFailedF
 }
 
 func (suite *PersistentVolumeControllerTestSuite) TestPVReconcileSameSc() {
-	//source sc = target sc
+	// source sc = target sc
 	sc1 := &storagev1.StorageClass{
 		ObjectMeta:  metav1.ObjectMeta{Name: "sc1"},
 		Provisioner: "provisionerName",
@@ -379,7 +379,7 @@ func (suite *PersistentVolumeControllerTestSuite) TestPVReconcileSameSc() {
 }
 
 func (suite *PersistentVolumeControllerTestSuite) TestPVReconcileNonReplToRepl() {
-	//migration type non repl to repl
+	// migration type non repl to repl
 	sc1 := &storagev1.StorageClass{
 		ObjectMeta:  metav1.ObjectMeta{Name: "sc1"},
 		Provisioner: "provisionerName",
@@ -432,7 +432,7 @@ func (suite *PersistentVolumeControllerTestSuite) TestPVReconcileNonReplToRepl()
 }
 
 func (suite *PersistentVolumeControllerTestSuite) TestPVReconcileReplToNonRepl() {
-	//migration type repl to non repl
+	// migration type repl to non repl
 	sc1 := &storagev1.StorageClass{
 		ObjectMeta:  metav1.ObjectMeta{Name: "sc1"},
 		Provisioner: "provisionerName",
@@ -486,7 +486,7 @@ func (suite *PersistentVolumeControllerTestSuite) TestPVReconcileReplToNonRepl()
 }
 
 func (suite *PersistentVolumeControllerTestSuite) TestPVReconcileVolumeMigrate() {
-	//volume migrate error
+	// volume migrate error
 	sc1 := &storagev1.StorageClass{
 		ObjectMeta:  metav1.ObjectMeta{Name: "sc1"},
 		Provisioner: "provisionerName",
@@ -536,7 +536,7 @@ func (suite *PersistentVolumeControllerTestSuite) TestPVReconcileVolumeMigrate()
 }
 
 func (suite *PersistentVolumeControllerTestSuite) TestPVReconcileNewPvFailedFetch() {
-	//new pv doesn't fetch
+	// new pv doesn't fetch
 
 	sc1 := &storagev1.StorageClass{
 		ObjectMeta:  metav1.ObjectMeta{Name: "sc1"},
@@ -589,7 +589,7 @@ func (suite *PersistentVolumeControllerTestSuite) TestPVReconcileNewPvFailedFetc
 }
 
 func (suite *PersistentVolumeControllerTestSuite) TestPVReconcileCreatePv() {
-	//new pv test
+	// new pv test
 	sc1 := &storagev1.StorageClass{
 		ObjectMeta:  metav1.ObjectMeta{Name: "sc1"},
 		Provisioner: "provisionerName",
@@ -642,7 +642,7 @@ func (suite *PersistentVolumeControllerTestSuite) TestPVReconcileCreatePv() {
 }
 
 func (suite *PersistentVolumeControllerTestSuite) TestPVReconcileUpdate() {
-	//update test
+	// update test
 	sc1 := &storagev1.StorageClass{
 		ObjectMeta:  metav1.ObjectMeta{Name: "sc1"},
 		Provisioner: "provisionerName",
@@ -708,7 +708,7 @@ func (suite *PersistentVolumeControllerTestSuite) getTypicalReconcileRequest(nam
 }
 
 func (suite *PersistentVolumeControllerTestSuite) getParams() map[string]string {
-	//creating fake PV to use with fake PVC
+	// creating fake PV to use with fake PVC
 	volumeAttributes := map[string]string{
 		"param1":                                 "val1",
 		"param2":                                 "val2",

--- a/controllers/csi-node-rescanner/dellcsimigrationgroup_controller.go
+++ b/controllers/csi-node-rescanner/dellcsimigrationgroup_controller.go
@@ -118,7 +118,6 @@ func (r *NodeRescanReconciler) processMGForRescan(ctx context.Context, mg *stora
 				return ctrl.Result{}, nil
 			}
 		}
-
 	}
 	if myNode.Name == "" {
 		return ctrl.Result{}, errors.NewBadRequest("no node name found")

--- a/controllers/csi-replicator/dellcsireplicationgroup_controller.go
+++ b/controllers/csi-replicator/dellcsireplicationgroup_controller.go
@@ -374,7 +374,7 @@ func (r *ReplicationGroupReconciler) getAction(actionType ActionType) (*csiext.E
 		}
 		actionT := supportedAction.GetType()
 		if actionT.String() == actionType.String() {
-			var action = &csiext.ExecuteActionRequest_Action{
+			action := &csiext.ExecuteActionRequest_Action{
 				Action: &csiext.Action{},
 			}
 			action.Action.ActionTypes = actionT
@@ -483,7 +483,8 @@ func resetRGSpecForInvalidAction(rg *repv1.DellCSIReplicationGroup) {
 }
 
 func (r *ReplicationGroupReconciler) processRGInActionInProgressState(ctx context.Context,
-	rg *repv1.DellCSIReplicationGroup) (ctrl.Result, error) {
+	rg *repv1.DellCSIReplicationGroup,
+) (ctrl.Result, error) {
 	log := common.GetLoggerFromContext(ctx)
 	// Get action in progress from annotation
 	inProgress, err := getActionInProgress(ctx, rg.Annotations)
@@ -609,7 +610,8 @@ func (r *ReplicationGroupReconciler) processRGInActionInProgressState(ctx contex
 }
 
 func (r *ReplicationGroupReconciler) executeAction(ctx context.Context, rg *repv1.DellCSIReplicationGroup,
-	actionType ActionType, action *csiext.ExecuteActionRequest_Action) *ActionResult {
+	actionType ActionType, action *csiext.ExecuteActionRequest_Action,
+) *ActionResult {
 	log := common.GetLoggerFromContext(ctx)
 	log.V(common.InfoLevel).Info("Executing action", "actionType", actionType)
 

--- a/controllers/csi-replicator/dellcsireplicationgroup_controller_test.go
+++ b/controllers/csi-replicator/dellcsireplicationgroup_controller_test.go
@@ -106,7 +106,7 @@ func (suite *RGControllerTestSuite) initReconciler() {
 func TestRGControllerTestSuite(t *testing.T) {
 	testSuite := new(RGControllerTestSuite)
 	suite.Run(t, testSuite)
-	//testSuite.TearDownTestSuite()
+	// testSuite.TearDownTestSuite()
 }
 
 func (suite *RGControllerTestSuite) TearDownTest() {
@@ -114,7 +114,7 @@ func (suite *RGControllerTestSuite) TearDownTest() {
 }
 
 func (suite *RGControllerTestSuite) getLocalRG(name string) repv1.DellCSIReplicationGroup {
-	//creating fake replication group
+	// creating fake replication group
 	if name == "" {
 		name = suite.driver.RGName
 	}
@@ -124,7 +124,7 @@ func (suite *RGControllerTestSuite) getLocalRG(name string) repv1.DellCSIReplica
 }
 
 func (suite *RGControllerTestSuite) getRemoteRG(name string) repv1.DellCSIReplicationGroup {
-	//creating fake replication group
+	// creating fake replication group
 	if name == "" {
 		name = suite.driver.RGName
 	}
@@ -134,8 +134,8 @@ func (suite *RGControllerTestSuite) getRemoteRG(name string) repv1.DellCSIReplic
 }
 
 func (suite *RGControllerTestSuite) createRGInActionInProgressState(name string, actionName string,
-	completed bool, deleteInProgress bool) (*repv1.DellCSIReplicationGroup, error) {
-
+	completed bool, deleteInProgress bool,
+) (*repv1.DellCSIReplicationGroup, error) {
 	rg := suite.getLocalRG(name)
 	actionType := ActionType(actionName)
 	rg.Spec.Action = actionName
@@ -192,14 +192,14 @@ func areAnnotationsEqual(expected, got ActionAnnotation) bool {
 }
 
 func (suite *RGControllerTestSuite) TestReconcileWithNoObject() {
-	//scenario: Reconcile for an object which doesn't exist (has been deleted)
+	// scenario: Reconcile for an object which doesn't exist (has been deleted)
 	req := suite.getTypicalReconcileRequest(suite.driver.RGName)
 	_, err := suite.rgReconcile.Reconcile(context.Background(), req)
 	suite.NoError(err, "No error on RG reconcile")
 }
 
 func (suite *RGControllerTestSuite) TestReconcileWithNoState() {
-	//scenario: When there is no state
+	// scenario: When there is no state
 	ctx := context.Background()
 	replicationGroup := suite.getLocalRG("")
 	err := suite.client.Create(ctx, &replicationGroup)
@@ -209,7 +209,7 @@ func (suite *RGControllerTestSuite) TestReconcileWithNoState() {
 	suite.NoError(err, "No error on RG reconcile")
 	suite.Equal(true, resp.Requeue, "Requeue is set to true")
 
-	//Reconcile again
+	// Reconcile again
 	_, err = suite.rgReconcile.Reconcile(context.Background(), req)
 	suite.NoError(err, "No error on RG reconcile")
 
@@ -218,11 +218,10 @@ func (suite *RGControllerTestSuite) TestReconcileWithNoState() {
 	suite.NoError(err, "No error on RG get")
 	suite.Equal(ReadyState, rg.Status.State, "State should be Ready")
 	suite.Contains(rg.Finalizers, controllers.ReplicationFinalizer, "Finalizer should be present")
-
 }
 
 func (suite *RGControllerTestSuite) TestReconcileWithEmptyPGID() {
-	//scenario: When there is no protection group ID and no valid state is set
+	// scenario: When there is no protection group ID and no valid state is set
 	ctx := context.Background()
 	replicationGroup := suite.getLocalRG("")
 	replicationGroup.Spec.ProtectionGroupID = ""
@@ -238,7 +237,7 @@ func (suite *RGControllerTestSuite) TestReconcileWithEmptyPGID() {
 }
 
 func (suite *RGControllerTestSuite) TestDeleteWithInvalidState() {
-	//scenario: When there is valid deletion time-stamp and invalid state
+	// scenario: When there is valid deletion time-stamp and invalid state
 	ctx := context.Background()
 	replicationGroup := suite.getLocalRG("")
 	replicationGroup.DeletionTimestamp = &metav1.Time{
@@ -255,7 +254,7 @@ func (suite *RGControllerTestSuite) TestDeleteWithInvalidState() {
 }
 
 func (suite *RGControllerTestSuite) TestReconcileWithInvalidStateRepeated() {
-	//scenario: When there is invalid state
+	// scenario: When there is invalid state
 	ctx := context.Background()
 	replicationGroup := suite.getLocalRG("")
 	replicationGroup.Spec.ProtectionGroupID = ""
@@ -273,7 +272,7 @@ func (suite *RGControllerTestSuite) TestReconcileWithInvalidStateRepeated() {
 }
 
 func (suite *RGControllerTestSuite) TestReconcileWithInvalidStateAfterFix() {
-	//scenario: When there is invalid state
+	// scenario: When there is invalid state
 	// and PGID has been added back
 	ctx := context.Background()
 	replicationGroup := suite.getLocalRG("")
@@ -292,7 +291,7 @@ func (suite *RGControllerTestSuite) TestReconcileWithInvalidStateAfterFix() {
 }
 
 func (suite *RGControllerTestSuite) TestDeleteWithInvalidStateAndNoPGID() {
-	//scenario: When there is valid deletion time-stamp and invalid state
+	// scenario: When there is valid deletion time-stamp and invalid state
 	ctx := context.Background()
 	replicationGroup := suite.getLocalRG("")
 	replicationGroup.DeletionTimestamp = &metav1.Time{
@@ -343,7 +342,7 @@ func (suite *RGControllerTestSuite) TestDeleteWithNoPGID() {
 }
 
 func (suite *RGControllerTestSuite) TestDeleteWithNoState() {
-	//scenario: When there is valid deletion time-stamp and no state
+	// scenario: When there is valid deletion time-stamp and no state
 	ctx := context.Background()
 	replicationGroup := suite.getLocalRG("")
 	replicationGroup.DeletionTimestamp = &metav1.Time{
@@ -359,7 +358,7 @@ func (suite *RGControllerTestSuite) TestDeleteWithNoState() {
 }
 
 func (suite *RGControllerTestSuite) TestDeleteWithReadyState() {
-	//scenario: When there is valid deletion time-stamp and Ready state
+	// scenario: When there is valid deletion time-stamp and Ready state
 	ctx := context.Background()
 	replicationGroup := suite.getLocalRG("")
 	// Set Finalizer
@@ -380,7 +379,7 @@ func (suite *RGControllerTestSuite) TestDeleteWithReadyState() {
 }
 
 func (suite *RGControllerTestSuite) TestDeleteWithErrors() {
-	//scenario: When there is valid deletion time-stamp and Ready state
+	// scenario: When there is valid deletion time-stamp and Ready state
 	ctx := context.Background()
 	replicationGroup := suite.getLocalRG("")
 	// Set Finalizer
@@ -482,12 +481,11 @@ func (suite *RGControllerTestSuite) TestDeleteWithFinalError() {
 	// Object should be deleted now
 	err = suite.client.Get(ctx, req.NamespacedName, rg)
 	suite.Error(err, "RG object not found")
-
 }
 
 func (suite *RGControllerTestSuite) TestDeleteWithActionInProgress() {
 	ctx := context.Background()
-	//scenario: When there is valid PG-ID and state is in ActionInProgress
+	// scenario: When there is valid PG-ID and state is in ActionInProgress
 	actionName := "Resume"
 	replicationGroup, err := suite.createRGInActionInProgressState("", actionName, false, true)
 	suite.Nil(err)
@@ -533,7 +531,7 @@ func (suite *RGControllerTestSuite) prettyPrint(rg repv1.DellCSIReplicationGroup
 }
 
 func (suite *RGControllerTestSuite) TestActionInReadyState() {
-	//scenario: When there is valid PG-ID and Suspend action
+	// scenario: When there is valid PG-ID and Suspend action
 	actionName := "Suspend"
 	actionType := ActionType(actionName)
 
@@ -571,7 +569,7 @@ func (suite *RGControllerTestSuite) TestActionInReadyState() {
 }
 
 func (suite *RGControllerTestSuite) TestActionInProgressState() {
-	//scenario: When there is valid PG-ID and state is in ActionInProgress
+	// scenario: When there is valid PG-ID and state is in ActionInProgress
 	actionName := "Failover_Local"
 	replicationGroup, err := suite.createRGInActionInProgressState("", actionName, false, false)
 	suite.Nil(err)
@@ -747,7 +745,7 @@ func (suite *RGControllerTestSuite) TestActionInProgressWithFinalError() {
 }
 
 func (suite *RGControllerTestSuite) TestActionInProgressStateWithPersistentError() {
-	//scenario: When there is valid PG-ID and state is in ActionInProgress
+	// scenario: When there is valid PG-ID and state is in ActionInProgress
 	// and driver returns errors
 	actionName := "Failback_Local"
 	actionType := ActionType(actionName)
@@ -792,7 +790,7 @@ func (suite *RGControllerTestSuite) TestActionInProgressStateWithPersistentError
 }
 
 func (suite *RGControllerTestSuite) TestActionInProgressStateWithTimeout() {
-	//scenario: When there is valid PG-ID and state is in ActionInProgress
+	// scenario: When there is valid PG-ID and state is in ActionInProgress
 	// and driver returns errors
 	actionName := "Failover_Remote"
 	actionType := ActionType(actionName)
@@ -1025,8 +1023,8 @@ func (suite *RGControllerTestSuite) TestActionInProgressWithIncorrectAnnotation(
 }
 
 func (suite *RGControllerTestSuite) TestActionInProgressWithMismatchingAction() {
-	//scenario: State is ActionInProgress, correct ActionInProgress annotation & user modifies the action field
-	//expectation: controller ignores this & finishes the current action
+	// scenario: State is ActionInProgress, correct ActionInProgress annotation & user modifies the action field
+	// expectation: controller ignores this & finishes the current action
 	actionName := "Sync"
 	replicationGroup, err := suite.createRGInActionInProgressState("", actionName, false, false)
 	suite.Nil(err)
@@ -1171,7 +1169,7 @@ func (suite *RGControllerTestSuite) TestInvalidAction() {
 }
 
 func (suite *RGControllerTestSuite) TestNoDeletionTimeStamp() {
-	//scenario: When there is no deletion time stamp
+	// scenario: When there is no deletion time stamp
 	replicationGroup := suite.getLocalRG("")
 	replicationGroup.Finalizers = append(replicationGroup.Finalizers, controllers.ReplicationFinalizer)
 

--- a/controllers/csi-replicator/monitoring.go
+++ b/controllers/csi-replicator/monitoring.go
@@ -47,7 +47,7 @@ type ReplicationGroupMonitoring struct {
 // Monitor polls RGs over a defined interval and
 // updates the ReplicationLinkStatus depending on the response received
 // from the driver.
-func (r *ReplicationGroupMonitoring) Monitor(ctx context.Context) error {
+func (r *ReplicationGroupMonitoring) Monitor(_ context.Context) error {
 	ticker := time.NewTicker(r.MonitoringInterval).C
 	go func(<-chan time.Time) {
 		for {

--- a/controllers/csi-replicator/monitoring.go
+++ b/controllers/csi-replicator/monitoring.go
@@ -59,7 +59,6 @@ func (r *ReplicationGroupMonitoring) Monitor(ctx context.Context) error {
 }
 
 func (r *ReplicationGroupMonitoring) monitorReplicationGroups(ticker <-chan time.Time) {
-
 	r.Log.V(common.InfoLevel).Info("Start monitoring replication-group")
 
 	dellCSIReplicationGroupsList := new(repv1.DellCSIReplicationGroupList)
@@ -165,7 +164,8 @@ func updateRGLinkState(rg *repv1.DellCSIReplicationGroup, status string, isSourc
 }
 
 func updateRGLinkStatus(ctx context.Context, client client.Client, rg *repv1.DellCSIReplicationGroup, status string,
-	isSource bool, errMsg string) error {
+	isSource bool, errMsg string,
+) error {
 	log := common.GetLoggerFromContext(ctx)
 	updateRGLinkState(rg, status, isSource, errMsg)
 	if err := client.Status().Update(ctx, rg); err != nil {

--- a/controllers/csi-replicator/monitoring_test.go
+++ b/controllers/csi-replicator/monitoring_test.go
@@ -45,7 +45,6 @@ func (suite *MonitoringControllerTestSuite) SetupSuite() {
 }
 
 func (suite *MonitoringControllerTestSuite) SetupTest() {
-
 }
 
 func (suite *MonitoringControllerTestSuite) getRGs() []client.Object {

--- a/controllers/csi-replicator/persistentvolume_controller.go
+++ b/controllers/csi-replicator/persistentvolume_controller.go
@@ -110,9 +110,7 @@ func (r *PersistentVolumeReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	}
 
-	var (
-		replicationGroupName string
-	)
+	var replicationGroupName string
 
 	log.V(common.InfoLevel).Info("Adding replication-group, remote storage class annotation and label to the PersistentVolume")
 
@@ -175,7 +173,8 @@ func (r *PersistentVolumeReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 func (r *PersistentVolumeReconciler) processVolumeForReplicationGroup(ctx context.Context, volume *v1.PersistentVolume,
 	replicationGroupName string,
-	scParams map[string]string) error {
+	scParams map[string]string,
+) error {
 	log := common.GetLoggerFromContext(ctx)
 	log.V(common.InfoLevel).Info("Begin process volume for replication-group")
 
@@ -366,7 +365,6 @@ func (r *PersistentVolumeReconciler) SetupWithManager(ctx context.Context, mgr c
 // getProtectionGroupID take a DellCSIReplicationGroup instance and returns its protection group ID.
 // It satisfies the IndexerFunc type in controller-runtime/pkg/client/interfaces
 func getProtectionGroupID(object client.Object) []string {
-
 	replicationGroup := object.(*repv1.DellCSIReplicationGroup)
 	if replicationGroup.Spec.ProtectionGroupID != "" {
 		return []string{replicationGroup.Spec.ProtectionGroupID}

--- a/controllers/csi-replicator/persistentvolume_controller_test.go
+++ b/controllers/csi-replicator/persistentvolume_controller_test.go
@@ -196,7 +196,6 @@ func (suite *PersistentVolumeControllerTestSuite) TestRGAdd() {
 	newRGName := newUpdatedPV.Annotations[controllers.ReplicationGroup]
 	// Check if this is the same as old rg name
 	suite.Equal(rgName, newRGName, "PV should be added to same RG")
-
 }
 
 func (suite *PersistentVolumeControllerTestSuite) TestPVReconcileDifferentDriver() {
@@ -308,7 +307,7 @@ func (suite *PersistentVolumeControllerTestSuite) TestPVCExistsScenario() {
 	err := suite.client.Create(context.Background(), pvObj)
 	suite.NoError(err)
 
-	//creating fake PVC with bound state
+	// creating fake PVC with bound state
 	pvcObj := utils.GetPVCObj("fake-pvc12", suite.driver.Namespace, suite.driver.StorageClass)
 	pvcObj.Status.Phase = corev1.ClaimBound
 	pvcObj.Spec.VolumeName = pvName
@@ -341,7 +340,7 @@ func (suite *PersistentVolumeControllerTestSuite) TestPVProtectionCompleteAnnota
 }
 
 func (suite *PersistentVolumeControllerTestSuite) getParams() map[string]string {
-	//creating fake PV to use with fake PVC
+	// creating fake PV to use with fake PVC
 	volumeAttributes := map[string]string{
 		"param1":                                 "val1",
 		"param2":                                 "val2",
@@ -355,7 +354,7 @@ func (suite *PersistentVolumeControllerTestSuite) getFakePV(name string) *corev1
 }
 
 func (suite *PersistentVolumeControllerTestSuite) getFakeStorageClass() *storagev1.StorageClass {
-	//creating fake storage-class with replication params
+	// creating fake storage-class with replication params
 	sc := utils.GetReplicationEnabledSC(suite.driver.DriverName, suite.driver.StorageClass, suite.driver.RemoteSCName,
 		suite.driver.RemoteClusterID)
 	return sc

--- a/controllers/csi-replicator/persistentvolumeclaim_controller.go
+++ b/controllers/csi-replicator/persistentvolumeclaim_controller.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2021-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/controllers/csi-replicator/persistentvolumeclaim_controller.go
+++ b/controllers/csi-replicator/persistentvolumeclaim_controller.go
@@ -176,7 +176,8 @@ func (r *PersistentVolumeClaimReconciler) Reconcile(ctx context.Context, req ctr
 }
 
 func (r *PersistentVolumeClaimReconciler) processClaimForRemoteVolume(ctx context.Context, claim *v1.PersistentVolumeClaim,
-	pv *v1.PersistentVolume, scParams map[string]string, buffer string) error {
+	pv *v1.PersistentVolume, scParams map[string]string, buffer string,
+) error {
 	log := common.GetLoggerFromContext(ctx)
 	log.V(common.InfoLevel).Info("Begin process claim for remote-volume")
 

--- a/controllers/csi-replicator/persistentvolumeclaim_controller_test.go
+++ b/controllers/csi-replicator/persistentvolumeclaim_controller_test.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2021-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/controllers/csi-replicator/persistentvolumeclaim_controller_test.go
+++ b/controllers/csi-replicator/persistentvolumeclaim_controller_test.go
@@ -45,8 +45,10 @@ type PVControllerTestSuite struct {
 }
 
 // blank assignment to verify client.Client method implementations
-var _ client.Client = &fakeclient.Client{}
-var PVCReconciler PersistentVolumeClaimReconciler
+var (
+	_             client.Client = &fakeclient.Client{}
+	PVCReconciler PersistentVolumeClaimReconciler
+)
 
 func (suite *PVControllerTestSuite) SetupTest() {
 	suite.Init()
@@ -88,7 +90,7 @@ func (suite *PVControllerTestSuite) runFakeReplicationManager() {
 }
 
 func (suite *PVControllerTestSuite) TestVolumeCreationFail() {
-	//scenario: CreateRemoteVolume should fail with an error
+	// scenario: CreateRemoteVolume should fail with an error
 	var dummyBuffer string
 	ctx := context.Background()
 	pvObj := suite.getFakePV()
@@ -97,7 +99,7 @@ func (suite *PVControllerTestSuite) TestVolumeCreationFail() {
 	err := suite.mockUtils.FakeControllerClient.Create(ctx, pvObj)
 	assert.NoError(suite.T(), err)
 
-	//creating fake PVC with bound state
+	// creating fake PVC with bound state
 	pvcObj := utils.GetPVCObj("fake-pvc1", suite.mockUtils.Specs.Namespace, suite.driver.StorageClass)
 	pvcObj.Status.Phase = corev1.ClaimBound
 	pvcObj.Spec.VolumeName = "fake-pv1"
@@ -118,7 +120,7 @@ func (suite *PVControllerTestSuite) TestVolumeCreationFail() {
 }
 
 func (suite *PVControllerTestSuite) TestPVProcessingFailure() {
-	//scenario: PV processing should fail with an error
+	// scenario: PV processing should fail with an error
 	ctx := context.Background()
 	pvObj := suite.getFakePV()
 	pvObj.Name = "fake-pv2"
@@ -126,7 +128,7 @@ func (suite *PVControllerTestSuite) TestPVProcessingFailure() {
 	err := suite.mockUtils.FakeControllerClient.Create(ctx, pvObj)
 	assert.NoError(suite.T(), err)
 
-	//creating fake PVC with bound state
+	// creating fake PVC with bound state
 	pvcObj := utils.GetPVCObj("fake-pvc2", suite.mockUtils.Specs.Namespace, suite.driver.StorageClass)
 	pvcObj.Status.Phase = corev1.ClaimBound
 	pvcObj.Spec.VolumeName = "fake-pv2"
@@ -148,7 +150,7 @@ func (suite *PVControllerTestSuite) TestPVProcessingFailure() {
 }
 
 func (suite *PVControllerTestSuite) TestRGCreationFailure() {
-	//scenario: CreateRG should fail with an error
+	// scenario: CreateRG should fail with an error
 	ctx := context.Background()
 	pvObj := suite.getFakePV()
 	pvObj.Name = "fake-pv3"
@@ -156,7 +158,7 @@ func (suite *PVControllerTestSuite) TestRGCreationFailure() {
 	err := suite.mockUtils.FakeControllerClient.Create(ctx, pvObj)
 	assert.NoError(suite.T(), err)
 
-	//creating fake PVC with bound state
+	// creating fake PVC with bound state
 	pvcObj := utils.GetPVCObj("fake-pvc3", suite.mockUtils.Specs.Namespace, suite.driver.StorageClass)
 	pvcObj.Status.Phase = corev1.ClaimBound
 	pvcObj.Spec.VolumeName = "fake-pv3"
@@ -178,7 +180,7 @@ func (suite *PVControllerTestSuite) TestRGCreationFailure() {
 }
 
 func (suite *PVControllerTestSuite) TestWithoutStorageClass() {
-	//scenario: When there is no storage class created
+	// scenario: When there is no storage class created
 	ctx := context.Background()
 	pvObj := suite.getFakePV()
 	pvObj.Name = "fake-pv4"
@@ -186,7 +188,7 @@ func (suite *PVControllerTestSuite) TestWithoutStorageClass() {
 	err := suite.mockUtils.FakeControllerClient.Create(ctx, pvObj)
 	assert.NoError(suite.T(), err)
 
-	//creating fake PVC with bound state
+	// creating fake PVC with bound state
 	sc := ""
 	pvcObj := utils.GetPVCObj("fake-pvc4", suite.mockUtils.Specs.Namespace, suite.driver.StorageClass)
 	pvcObj.Status.Phase = corev1.ClaimBound
@@ -208,7 +210,7 @@ func (suite *PVControllerTestSuite) TestWithoutStorageClass() {
 }
 
 func (suite *PVControllerTestSuite) TestWithReplicationDisabledSc() {
-	//scenario: When the storage class is not replication enabled
+	// scenario: When the storage class is not replication enabled
 	ctx := context.Background()
 	scObj := suite.getFakeStorageClass()
 	scObj.Name = "fake-sc-5"
@@ -224,7 +226,7 @@ func (suite *PVControllerTestSuite) TestWithReplicationDisabledSc() {
 	err = suite.mockUtils.FakeControllerClient.Create(ctx, pvObj)
 	assert.NoError(suite.T(), err)
 
-	//creating fake PVC with bound state
+	// creating fake PVC with bound state
 	pvcObj := utils.GetPVCObj("fake-pvc5", suite.mockUtils.Specs.Namespace, suite.driver.StorageClass)
 	scName := "fake-sc-5"
 	pvcObj.Status.Phase = corev1.ClaimBound
@@ -246,7 +248,7 @@ func (suite *PVControllerTestSuite) TestWithReplicationDisabledSc() {
 }
 
 func (suite *PVControllerTestSuite) TestWithInvalidStorageClass() {
-	//scenario: When there is no remote-storage class added in the storage class
+	// scenario: When there is no remote-storage class added in the storage class
 	ctx := context.Background()
 	scObj := suite.getFakeStorageClass()
 	scObj.Name = "fake-sc-6"
@@ -273,7 +275,7 @@ func (suite *PVControllerTestSuite) TestWithInvalidStorageClass() {
 	err = suite.mockUtils.FakeControllerClient.Create(ctx, pvObj)
 	assert.NoError(suite.T(), err)
 
-	//creating fake PVC with bound state
+	// creating fake PVC with bound state
 	pvcObj := utils.GetPVCObj("fake-pvc6", suite.mockUtils.Specs.Namespace, suite.driver.StorageClass)
 	pvcObj.Status.Phase = corev1.ClaimBound
 	pvcObj.Spec.VolumeName = "fake-pv6"
@@ -295,7 +297,7 @@ func (suite *PVControllerTestSuite) TestWithInvalidStorageClass() {
 }
 
 func (suite *PVControllerTestSuite) TestWithInvalidVolumeHandle() {
-	//scenario: CreateRemoteVolume should fail with invalid volumeHandle
+	// scenario: CreateRemoteVolume should fail with invalid volumeHandle
 	pvObj := suite.getFakePV()
 	pvObj.Name = "fake-pv7"
 	pvObj.Spec.CSI.VolumeHandle = ""
@@ -303,7 +305,7 @@ func (suite *PVControllerTestSuite) TestWithInvalidVolumeHandle() {
 	err := suite.mockUtils.FakeControllerClient.Create(context.Background(), pvObj)
 	assert.NoError(suite.T(), err)
 
-	//creating fake PVC with bound state
+	// creating fake PVC with bound state
 	pvcObj := utils.GetPVCObj("fake-pvc7", suite.mockUtils.Specs.Namespace, suite.driver.StorageClass)
 	pvcObj.Status.Phase = corev1.ClaimBound
 	pvcObj.Spec.VolumeName = "fake-pv7"
@@ -323,14 +325,14 @@ func (suite *PVControllerTestSuite) TestWithInvalidVolumeHandle() {
 }
 
 func (suite *PVControllerTestSuite) TestWhenPVCNotInBound() {
-	//scenario: When the PVC is not bound
+	// scenario: When the PVC is not bound
 	pvObj := suite.getFakePV()
 	pvObj.Name = "fake-pv8"
 
 	err := suite.mockUtils.FakeControllerClient.Create(context.Background(), pvObj)
 	assert.NoError(suite.T(), err)
 
-	//creating fake PVC with bound state
+	// creating fake PVC with bound state
 	pvcObj := utils.GetPVCObj("fake-pvc8", suite.mockUtils.Specs.Namespace, suite.driver.StorageClass)
 	pvcObj.Status.Phase = ""
 	pvcObj.Spec.VolumeName = "fake-pv8"
@@ -349,7 +351,7 @@ func (suite *PVControllerTestSuite) TestWhenPVCNotInBound() {
 }
 
 func (suite *PVControllerTestSuite) TestInvalidVolumeName() {
-	//scenario: When there is no volume name present in the PVC
+	// scenario: When there is no volume name present in the PVC
 	pvcObj := utils.GetPVCObj("fake-pvc9", suite.mockUtils.Specs.Namespace, suite.driver.StorageClass)
 	pvcObj.Status.Phase = ""
 	pvcObj.Spec.VolumeName = ""
@@ -369,7 +371,7 @@ func (suite *PVControllerTestSuite) TestInvalidVolumeName() {
 }
 
 func (suite *PVControllerTestSuite) TestReconcileWithInvalidObjects() {
-	//scenario: When the resource names are not valid
+	// scenario: When the resource names are not valid
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{
 			Namespace: "",
@@ -381,7 +383,7 @@ func (suite *PVControllerTestSuite) TestReconcileWithInvalidObjects() {
 }
 
 func (suite *PVControllerTestSuite) TestWithInvalidDriver() {
-	//scenario: When the provisioner name and driver name doesn't match
+	// scenario: When the provisioner name and driver name doesn't match
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{
 			Namespace: suite.mockUtils.Specs.Namespace,
@@ -394,7 +396,7 @@ func (suite *PVControllerTestSuite) TestWithInvalidDriver() {
 }
 
 func (suite *PVControllerTestSuite) TestPVCReconciliation() {
-	//scenario: Positive scenario
+	// scenario: Positive scenario
 	ctx := context.Background()
 	pvObj := suite.getFakePV()
 	pvObj.Name = "fake-pv10"
@@ -408,7 +410,7 @@ func (suite *PVControllerTestSuite) TestPVCReconciliation() {
 	err := suite.mockUtils.FakeControllerClient.Create(ctx, pvObj)
 	assert.NoError(suite.T(), err)
 
-	//creating fake PVC with bound state
+	// creating fake PVC with bound state
 	pvcObj := utils.GetPVCObj("fake-pvc10", suite.mockUtils.Specs.Namespace, suite.driver.StorageClass)
 	pvcObj.Status.Phase = corev1.ClaimBound
 	pvcObj.Spec.VolumeName = "fake-pv10"
@@ -432,11 +434,10 @@ func (suite *PVControllerTestSuite) TestPVCReconciliation() {
 
 	suite.Equal(updatedPVC.Namespace, suite.mockUtils.Specs.Namespace, "They should be equal")
 	utils.ValidateAnnotations(updatedPVC.ObjectMeta.Annotations, suite.T())
-
 }
 
 func (suite *PVControllerTestSuite) TestPVCReconciliationWithEmptyRG() {
-	//scenario: Negative scenario when RG annotation is empty
+	// scenario: Negative scenario when RG annotation is empty
 	ctx := context.Background()
 	pvObj := suite.getFakePV()
 	pvObj.Name = "fake-pv10"
@@ -450,7 +451,7 @@ func (suite *PVControllerTestSuite) TestPVCReconciliationWithEmptyRG() {
 	err := suite.mockUtils.FakeControllerClient.Create(ctx, pvObj)
 	assert.NoError(suite.T(), err)
 
-	//creating fake PVC with bound state
+	// creating fake PVC with bound state
 	pvcObj := utils.GetPVCObj("fake-pvc10", suite.mockUtils.Specs.Namespace, suite.driver.StorageClass)
 	pvcObj.Status.Phase = corev1.ClaimBound
 	pvcObj.Spec.VolumeName = "fake-pv10"
@@ -470,7 +471,7 @@ func (suite *PVControllerTestSuite) TestPVCReconciliationWithEmptyRG() {
 }
 
 func (suite *PVControllerTestSuite) TestPVCReconciliationWithMissingRGAnnotation() {
-	//scenario: Negative scenario when RG annotation is not set on PV
+	// scenario: Negative scenario when RG annotation is not set on PV
 	ctx := context.Background()
 	pvObj := suite.getFakePV()
 	pvObj.Name = "fake-pv10"
@@ -483,7 +484,7 @@ func (suite *PVControllerTestSuite) TestPVCReconciliationWithMissingRGAnnotation
 	err := suite.mockUtils.FakeControllerClient.Create(ctx, pvObj)
 	assert.NoError(suite.T(), err)
 
-	//creating fake PVC with bound state
+	// creating fake PVC with bound state
 	pvcObj := utils.GetPVCObj("fake-pvc10", suite.mockUtils.Specs.Namespace, suite.driver.StorageClass)
 	pvcObj.Status.Phase = corev1.ClaimBound
 	pvcObj.Spec.VolumeName = "fake-pv10"
@@ -503,7 +504,7 @@ func (suite *PVControllerTestSuite) TestPVCReconciliationWithMissingRGAnnotation
 }
 
 func (suite *PVControllerTestSuite) TestPVRetentionPolicyDelete() {
-	//scenario: When the PV Retention policy is set to delete
+	// scenario: When the PV Retention policy is set to delete
 	ctx := context.Background()
 	scObj := suite.getFakeStorageClass()
 	scObj.Name = "fake-sc-11"
@@ -519,7 +520,7 @@ func (suite *PVControllerTestSuite) TestPVRetentionPolicyDelete() {
 	err = suite.mockUtils.FakeControllerClient.Create(ctx, pvObj)
 	assert.NoError(suite.T(), err)
 
-	//creating fake PVC with bound state
+	// creating fake PVC with bound state
 	pvcObj := utils.GetPVCObj("fake-pvc11", suite.mockUtils.Specs.Namespace, suite.driver.StorageClass)
 	scName := "fake-sc-11"
 	pvcObj.Status.Phase = corev1.ClaimBound
@@ -541,7 +542,7 @@ func (suite *PVControllerTestSuite) TestPVRetentionPolicyDelete() {
 }
 
 func (suite *PVControllerTestSuite) TestUpdatingTerminatingObjects() {
-	//scenario: This should fail to update the PV which is in terminating state
+	// scenario: This should fail to update the PV which is in terminating state
 	ctx := context.Background()
 
 	pvObj := suite.getFakePV()
@@ -551,7 +552,7 @@ func (suite *PVControllerTestSuite) TestUpdatingTerminatingObjects() {
 	err := suite.mockUtils.FakeControllerClient.Create(ctx, pvObj)
 	assert.NoError(suite.T(), err)
 
-	//creating fake PVC with bound state
+	// creating fake PVC with bound state
 	pvcObj := utils.GetPVCObj("fake-pvc12", suite.mockUtils.Specs.Namespace, suite.driver.StorageClass)
 	pvcObj.Status.Phase = corev1.ClaimBound
 	pvcObj.Spec.VolumeName = "fake-pv12"
@@ -578,7 +579,7 @@ func (suite *PVControllerTestSuite) TestSetupWithManager() {
 }
 
 func (suite *PVControllerTestSuite) getFakePV() *corev1.PersistentVolume {
-	//creating fake PV to use with fake PVC
+	// creating fake PV to use with fake PVC
 	volumeAttributes := map[string]string{
 		"fake-CapacityGB":     "3.00",
 		"RemoteSYMID":         "000000000002",
@@ -626,7 +627,7 @@ func (suite *PVControllerTestSuite) getParams() map[string]string {
 }
 
 func (suite *PVControllerTestSuite) getFakeStorageClass() *storagev1.StorageClass {
-	//creating fake storage-class with replication params
+	// creating fake storage-class with replication params
 	parameters := suite.getParams()
 	scObj := storagev1.StorageClass{
 		ObjectMeta:  metav1.ObjectMeta{Name: suite.driver.StorageClass},

--- a/controllers/replication-controller/dellcsireplicationgroup_controller_test.go
+++ b/controllers/replication-controller/dellcsireplicationgroup_controller_test.go
@@ -49,6 +49,7 @@ type RGControllerTestSuite struct {
 func (suite *RGControllerTestSuite) SetupTest() {
 	suite.Init()
 }
+
 func (suite *RGControllerTestSuite) Init() {
 	controllers.InitLabelsAndAnnotations(constants.DefaultDomain)
 	suite.driver = utils.GetDefaultDriver()
@@ -89,14 +90,14 @@ func (suite *RGControllerTestSuite) getRemoteParams() map[string]string {
 }
 
 func (suite *RGControllerTestSuite) getLocalRG(name, clusterID string) *repv1.DellCSIReplicationGroup {
-	//creating fake resource group
+	// creating fake resource group
 	replicationGroup := utils.GetRGObj(name, suite.driver.DriverName, clusterID,
 		utils.LocalPGID, utils.RemotePGID, suite.getLocalParams(), suite.getRemoteParams())
 	return replicationGroup
 }
 
 func (suite *RGControllerTestSuite) getRemoteRG(name, clusterID string) *repv1.DellCSIReplicationGroup {
-	//creating fake resource group
+	// creating fake resource group
 	replicationGroup := utils.GetRGObj(name, suite.driver.DriverName, clusterID,
 		utils.RemotePGID, utils.LocalPGID, suite.getRemoteParams(), suite.getLocalParams())
 	return replicationGroup
@@ -330,7 +331,6 @@ func (suite *RGControllerTestSuite) TestReconcileRGWithAnnotationsSingleCluster(
 	suite.NoError(err)
 	suite.T().Log(replicatedRG.Annotations)
 	suite.T().Log(replicatedRG.Labels)
-
 }
 
 func (suite *RGControllerTestSuite) TestRGSyncWithFinalizer() {
@@ -356,7 +356,7 @@ func (suite *RGControllerTestSuite) TestRGSyncWithFinalizer() {
 	_, err = rClient.GetReplicationGroup(context.Background(), rg.Name)
 	suite.NoError(err)
 
-	//Delete rg
+	// Delete rg
 	err = suite.client.Delete(context.Background(), rg)
 	suite.NoError(err)
 }

--- a/controllers/replication-controller/persistentvolume_controller.go
+++ b/controllers/replication-controller/persistentvolume_controller.go
@@ -400,11 +400,12 @@ func (r *PersistentVolumeReconciler) Reconcile(ctx context.Context, req ctrl.Req
 }
 
 func (r *PersistentVolumeReconciler) processRemotePV(ctx context.Context,
-	rClient connection.RemoteClusterClient, remotePV *v1.PersistentVolume, remoteRGName string) (bool, error) {
+	rClient connection.RemoteClusterClient, remotePV *v1.PersistentVolume, remoteRGName string,
+) (bool, error) {
 	log := common.GetLoggerFromContext(ctx)
 	if remoteRGName != "" {
 		// Update the annotation for the remote PV object
-		//controller.AddAnnotation(remotePV, controller.ReplicationGroup, remoteRGName)
+		// controller.AddAnnotation(remotePV, controller.ReplicationGroup, remoteRGName)
 		if remotePV.Annotations[controller.ReplicationGroup] == "" {
 			// Set the annotation
 			log.V(common.DebugLevel).Info(fmt.Sprintf("Setting the ReplicationGroup label & annotation %s on remotePV %s", remoteRGName, remotePV.Name))

--- a/controllers/replication-controller/persistentvolume_controller.go
+++ b/controllers/replication-controller/persistentvolume_controller.go
@@ -438,7 +438,7 @@ func (r *PersistentVolumeReconciler) processLocalPV(ctx context.Context, localPV
 	if remotePVNameFromLocalPVAnnotation == "" {
 		controller.AddAnnotation(localPV, controller.RemotePV, remotePVName)
 		updatePV = true
-	} else if remotePVNameFromLocalPVAnnotation != remotePVName {
+		// } else if remotePVNameFromLocalPVAnnotation != remotePVName {
 		// Conflict - ??
 	} else {
 		log.V(common.InfoLevel).Info(fmt.Sprintf("%s already set to %s for local PV: %s",
@@ -448,7 +448,7 @@ func (r *PersistentVolumeReconciler) processLocalPV(ctx context.Context, localPV
 	if remoteClusterIDFromLocalPVAnnotation == "" {
 		controller.AddAnnotation(localPV, controller.RemoteClusterID, remoteClusterID)
 		updatePV = true
-	} else if remoteClusterIDFromLocalPVAnnotation != remoteClusterID {
+		// } else if remoteClusterIDFromLocalPVAnnotation != remoteClusterID {
 		// Conflict - ??
 	} else {
 		log.V(common.InfoLevel).Info(fmt.Sprintf("%s already set to %s for local PV: %s",

--- a/controllers/replication-controller/persistentvolumeclaim_controller.go
+++ b/controllers/replication-controller/persistentvolumeclaim_controller.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2021-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/controllers/replication-controller/persistentvolumeclaim_controller.go
+++ b/controllers/replication-controller/persistentvolumeclaim_controller.go
@@ -163,7 +163,8 @@ func (r *PersistentVolumeClaimReconciler) Reconcile(ctx context.Context, req ctr
 func (r *PersistentVolumeClaimReconciler) processRemotePVC(ctx context.Context,
 	rClient connection.RemoteClusterClient,
 	claim *v1.PersistentVolumeClaim,
-	remotePVCName, remotePVCNamespace, remotePVName string) (bool, error) {
+	remotePVCName, remotePVCNamespace, remotePVName string,
+) (bool, error) {
 	log := common.GetLoggerFromContext(ctx)
 	isUpdated := false
 	// Just apply the missing annotation
@@ -194,7 +195,8 @@ func (r *PersistentVolumeClaimReconciler) processRemotePVC(ctx context.Context,
 
 func (r *PersistentVolumeClaimReconciler) processLocalPVC(ctx context.Context,
 	claim *v1.PersistentVolumeClaim, remotePVName, remotePVCName, remotePVCNamespace,
-	remoteClusterID string, isRemotePVCUpdated bool) error {
+	remoteClusterID string, isRemotePVCUpdated bool,
+) error {
 	log := common.GetLoggerFromContext(ctx)
 	if claim.Annotations[controller.PVCSyncComplete] == "yes" {
 		log.V(common.InfoLevel).Info("PVC Sync already completed")

--- a/controllers/replication-controller/persistentvolumeclaim_controller_test.go
+++ b/controllers/replication-controller/persistentvolumeclaim_controller_test.go
@@ -48,8 +48,10 @@ type PVControllerTestSuite struct {
 }
 
 // blank assignment to verify client.Client method implementations
-var _ client.Client = &fakeclient.Client{}
-var externalReconcile PersistentVolumeClaimReconciler
+var (
+	_                 client.Client = &fakeclient.Client{}
+	externalReconcile PersistentVolumeClaimReconciler
+)
 
 func (suite *PVControllerTestSuite) SetupSuite() {
 	suite.Init()
@@ -62,7 +64,7 @@ func (suite *PVControllerTestSuite) Init() {
 }
 
 func (suite *PVControllerTestSuite) getPV() corev1.PersistentVolume {
-	//creating fake PV to use with our fake PVC
+	// creating fake PV to use with our fake PVC
 	volumeAttributes := map[string]string{
 		"fake-CapacityGB":     "3.00",
 		"RemoteSYMID":         "000000000002",
@@ -208,7 +210,6 @@ func (suite *PVControllerTestSuite) runFakeRemoteReplicationManager(fakeConfig c
 	remotePVC1.Annotations[controllers.PVCSyncComplete] = "yes"
 	e = externalReconcile.processLocalPVC(context.WithValue(context.TODO(), constants.LoggerContextKey, logger), remotePVC1, "xyz", "xyz", "xyz", "xyz", true)
 	assert.NoError(suite.T(), e, "No Error while processing local PVC")
-
 }
 
 func (suite *PVControllerTestSuite) TestRemoteReplication() {
@@ -230,7 +231,7 @@ func (suite *PVControllerTestSuite) TestRemoteReplication() {
 	err = remoteClient.CreatePersistentVolume(context.Background(), &pvObj)
 	assert.Nil(suite.T(), err)
 
-	//creating fake storage-class with replication params
+	// creating fake storage-class with replication params
 	parameters := map[string]string{
 		"RdfGroup":           "2",
 		"RdfMode":            "ASYNC",
@@ -252,7 +253,7 @@ func (suite *PVControllerTestSuite) TestRemoteReplication() {
 	err = suite.client.Create(ctx, &scObj)
 	assert.Nil(suite.T(), err)
 
-	//creating fake PV to use with our fake PVC
+	// creating fake PV to use with our fake PVC
 	pvObj = suite.getPV()
 	err = suite.client.Create(ctx, &pvObj)
 	assert.NotNil(suite.T(), pvObj)
@@ -263,12 +264,12 @@ func (suite *PVControllerTestSuite) TestRemoteReplication() {
 	annotations[controllers.RemoteClusterID] = "remote-123"
 	annotations[controllers.ContextPrefix] = "csi-fake"
 
-	//creating fake resource group
+	// creating fake resource group
 	resourceGroup := repv1.DellCSIReplicationGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "fake-rg",
 			Annotations: annotations,
-			//Namespace: suite.mockUtils.Specs.Namespace,
+			// Namespace: suite.mockUtils.Specs.Namespace,
 		},
 		Spec: repv1.DellCSIReplicationGroupSpec{
 			DriverName:                suite.driver.DriverName,
@@ -294,7 +295,6 @@ func (suite *PVControllerTestSuite) TestRemoteReplication() {
 	err = suite.client.Create(ctx, &resourceGroup)
 
 	suite.runFakeRemoteReplicationManager(suite.fakeConfig, remoteClient)
-
 }
 
 func (suite *PVControllerTestSuite) TestSetupWithManagerRg() {

--- a/deploy/controller.yaml
+++ b/deploy/controller.yaml
@@ -282,7 +282,7 @@ spec:
           value: /app/certs
         - name: X_CSI_REPLICATION_CONFIG_FILE_NAME
           value: config
-        image: dellemc/dell-replication-controller:v1.5.0
+        image: dellemc/dell-replication-controller:v1.6.0
         imagePullPolicy: Always
         name: manager
         resources:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2021-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -135,7 +135,6 @@ func (c *Config) UpdateConfigMap(ctx context.Context, client ctrlClient.Client, 
 }
 
 func (c *Config) updateConfig(ctx context.Context, client ctrlClient.Client, opts ControllerManagerOpts, recorder record.EventRecorder, log logr.Logger) error {
-
 	cmap, replicationConfig, err := getReplicationConfig(ctx, client, opts, recorder, log)
 	if err != nil {
 		return err
@@ -231,7 +230,6 @@ func readConfigFile(configFile, configPath string) (*replicationConfigMap, error
 }
 
 func getReplicationConfig(ctx context.Context, client ctrlClient.Client, opts ControllerManagerOpts, recorder record.EventRecorder, log logr.Logger) (*replicationConfigMap, *replicationConfig, error) {
-
 	configMap, err := readConfigFile(opts.ConfigFileName, opts.ConfigDir)
 	if err != nil {
 		return nil, nil, err
@@ -266,7 +264,6 @@ func getReplicationConfig(ctx context.Context, client ctrlClient.Client, opts Co
 		return configMap, repConfig, nil
 	}
 	return configMap, nil, nil
-
 }
 
 // Returns a connection handler for the remote clusters
@@ -284,7 +281,7 @@ func getConnHandler(ctx context.Context, targets []target, client ctrlClient.Cli
 			}
 		} else {
 			log.V(common.InfoLevel).Info("Expecting secret data to be in form of a service account token/custom format")
-			//restConfig, err = buildRestConfigFromCustomFormat(target.SecretRef, opts.WatchNamespace, client)
+			// restConfig, err = buildRestConfigFromCustomFormat(target.SecretRef, opts.WatchNamespace, client)
 			restConfig, err = buildRestConfigFromServiceAccountToken(ctx, target.SecretRef, opts.WatchNamespace, client, target.Address)
 			if err != nil {
 				return nil, err

--- a/pkg/config/fake_config.go
+++ b/pkg/config/fake_config.go
@@ -40,7 +40,7 @@ func New(source string, targets ...string) connection.MultiClusterClient {
 	}
 	for _, target := range targets {
 		obj := []runtime.Object{}
-		//creating fake storage-class with replication params
+		// creating fake storage-class with replication params
 		parameters := map[string]string{
 			"RdfGroup":           "2",
 			"RdfMode":            "ASYNC",

--- a/pkg/connection/k8sconnections.go
+++ b/pkg/connection/k8sconnections.go
@@ -93,7 +93,7 @@ func (k8sConnHandler *RemoteK8sConnHandler) getControllerClient(clusterID string
 	utilruntime.Must(s1.AddToScheme(scheme))
 	if clientConfig, ok := k8sConnHandler.configs[clusterID]; ok {
 		client, err := GetControllerClient(clientConfig, scheme)
-		//client, err := ctrlClient.New(clientConfig, ctrlClient.Options{Scheme: scheme})
+		// client, err := ctrlClient.New(clientConfig, ctrlClient.Options{Scheme: scheme})
 		if err != nil {
 			return nil, err
 		}
@@ -213,7 +213,6 @@ func (c *RemoteK8sControllerClient) GetReplicationGroup(ctx context.Context, rep
 // UpdateReplicationGroup updates replication group object in current cluster
 func (c *RemoteK8sControllerClient) UpdateReplicationGroup(ctx context.Context, replicationGroup *repv1.DellCSIReplicationGroup) error {
 	return c.Client.Update(ctx, replicationGroup)
-
 }
 
 // CreateReplicationGroup creates replication group object in current cluster

--- a/pkg/connection/pending_test.go
+++ b/pkg/connection/pending_test.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2021-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/pkg/connection/pending_test.go
+++ b/pkg/connection/pending_test.go
@@ -32,22 +32,26 @@ func TestPending(t *testing.T) {
 		differentIDs bool
 		errormsg     string
 	}{
-		{npending: 2,
+		{
+			npending:     2,
 			maxpending:   1,
 			differentIDs: true,
 			errormsg:     "overload",
 		},
-		{npending: 4,
+		{
+			npending:     4,
 			maxpending:   5,
 			differentIDs: true,
 			errormsg:     "none",
 		},
-		{npending: 2,
+		{
+			npending:     2,
 			maxpending:   5,
 			differentIDs: false,
 			errormsg:     "pending",
 		},
-		{npending: 0,
+		{
+			npending:     0,
 			maxpending:   1,
 			differentIDs: false,
 			errormsg:     "none",

--- a/pkg/csi-clients/identity/identity.go
+++ b/pkg/csi-clients/identity/identity.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2021-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/pkg/csi-clients/identity/identity.go
+++ b/pkg/csi-clients/identity/identity.go
@@ -110,7 +110,8 @@ func (r *identity) ProbeForever(ctx context.Context) (string, error) {
 
 // GetReplicationCapabilities queries driver for supported replication capabilities
 func (r *identity) GetReplicationCapabilities(ctx context.Context) (ReplicationCapabilitySet,
-	[]*replication.SupportedActions, error) {
+	[]*replication.SupportedActions, error,
+) {
 	r.log.V(common.InfoLevel).Info("Requesting replication capabilities")
 	tctx, cancel := context.WithTimeout(ctx, r.timeout)
 	defer cancel()

--- a/pkg/csi-clients/identity/identity_fake.go
+++ b/pkg/csi-clients/identity/identity_fake.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2021-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -55,7 +55,7 @@ type mockIdentity struct {
 	supportedActions []*replication.SupportedActions
 }
 
-func (m *mockIdentity) GetMigrationCapabilities(ctx context.Context) (MigrationCapabilitySet, error) {
+func (m *mockIdentity) GetMigrationCapabilities(_ context.Context) (MigrationCapabilitySet, error) {
 	// TODO implement me
 	panic("implement me")
 }
@@ -104,21 +104,21 @@ func NewFakeIdentityClient(name string) Identity {
 	}
 }
 
-func (m *mockIdentity) ProbeController(ctx context.Context) (string, bool, error) {
+func (m *mockIdentity) ProbeController(_ context.Context) (string, bool, error) {
 	if err := m.injectedError.getAndClearError(); err != nil {
 		return "", false, err
 	}
 	return m.name, true, nil
 }
 
-func (m *mockIdentity) ProbeForever(ctx context.Context) (string, error) {
+func (m *mockIdentity) ProbeForever(_ context.Context) (string, error) {
 	if err := m.injectedError.getAndClearError(); err != nil {
 		return "", err
 	}
 	return m.name, nil
 }
 
-func (m *mockIdentity) GetReplicationCapabilities(ctx context.Context) (ReplicationCapabilitySet,
+func (m *mockIdentity) GetReplicationCapabilities(_ context.Context) (ReplicationCapabilitySet,
 	[]*replication.SupportedActions, error,
 ) {
 	if err := m.injectedError.getAndClearError(); err != nil {

--- a/pkg/csi-clients/identity/identity_fake.go
+++ b/pkg/csi-clients/identity/identity_fake.go
@@ -56,7 +56,7 @@ type mockIdentity struct {
 }
 
 func (m *mockIdentity) GetMigrationCapabilities(ctx context.Context) (MigrationCapabilitySet, error) {
-	//TODO implement me
+	// TODO implement me
 	panic("implement me")
 }
 
@@ -119,7 +119,8 @@ func (m *mockIdentity) ProbeForever(ctx context.Context) (string, error) {
 }
 
 func (m *mockIdentity) GetReplicationCapabilities(ctx context.Context) (ReplicationCapabilitySet,
-	[]*replication.SupportedActions, error) {
+	[]*replication.SupportedActions, error,
+) {
 	if err := m.injectedError.getAndClearError(); err != nil {
 		return ReplicationCapabilitySet{}, []*replication.SupportedActions{}, err
 	}

--- a/pkg/csi-clients/migration/migration.go
+++ b/pkg/csi-clients/migration/migration.go
@@ -65,7 +65,6 @@ func (m *migration) VolumeMigrate(ctx context.Context, volumeHandle string, stor
 
 // ArrayMigrate
 func (m *migration) ArrayMigrate(ctx context.Context, migrateAction *csiext.ArrayMigrateRequest_Action, Params map[string]string) (*csiext.ArrayMigrateResponse, error) {
-
 	tc, cancel := context.WithTimeout(ctx, m.timeout)
 	defer cancel()
 	client := csiext.NewMigrationClient(m.conn)

--- a/pkg/csi-clients/migration/migration.go
+++ b/pkg/csi-clients/migration/migration.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2022-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/pkg/csi-clients/migration/migration_fake.go
+++ b/pkg/csi-clients/migration/migration_fake.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2022-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -68,8 +68,8 @@ func NewFakeMigrationClient(contextPrefix string) MockMigration {
 }
 
 // VolumeMigrate migrates volume
-func (m *MockMigration) VolumeMigrate(ctx context.Context, volumeHandle string, storageClass string, migrateType *csiext.VolumeMigrateRequest_Type,
-	scParams map[string]string, sourcescParams map[string]string, toClone bool,
+func (m *MockMigration) VolumeMigrate(_ context.Context, _ string, _ string, _ *csiext.VolumeMigrateRequest_Type,
+	_ map[string]string, _ map[string]string, _ bool,
 ) (*csiext.VolumeMigrateResponse, error) {
 	defer m.ClearError(false)
 	if err := m.injectedError.getError(); err != nil {
@@ -84,7 +84,7 @@ func (m *MockMigration) VolumeMigrate(ctx context.Context, volumeHandle string, 
 }
 
 // ArrayMigrate migrates volume from source array to target
-func (m *MockMigration) ArrayMigrate(ctx context.Context, migrateAction *csiext.ArrayMigrateRequest_Action, Params map[string]string) (*csiext.ArrayMigrateResponse, error) {
+func (m *MockMigration) ArrayMigrate(_ context.Context, migrateAction *csiext.ArrayMigrateRequest_Action, _ map[string]string) (*csiext.ArrayMigrateResponse, error) {
 	defer m.ClearError(false)
 	if err := m.injectedError.getError(); err != nil {
 		return nil, err

--- a/pkg/csi-clients/migration/migration_fake.go
+++ b/pkg/csi-clients/migration/migration_fake.go
@@ -69,8 +69,8 @@ func NewFakeMigrationClient(contextPrefix string) MockMigration {
 
 // VolumeMigrate migrates volume
 func (m *MockMigration) VolumeMigrate(ctx context.Context, volumeHandle string, storageClass string, migrateType *csiext.VolumeMigrateRequest_Type,
-	scParams map[string]string, sourcescParams map[string]string, toClone bool) (*csiext.VolumeMigrateResponse, error) {
-
+	scParams map[string]string, sourcescParams map[string]string, toClone bool,
+) (*csiext.VolumeMigrateResponse, error) {
 	defer m.ClearError(false)
 	if err := m.injectedError.getError(); err != nil {
 		return nil, err

--- a/pkg/csi-clients/replication/replication.go
+++ b/pkg/csi-clients/replication/replication.go
@@ -63,7 +63,7 @@ func (r *replication) GetStorageProtectionGroupStatus(ctx context.Context, prote
 		ProtectionGroupAttributes: attributes,
 	}
 
-	var rgID = connection.RgIDType(protectionGroupID)
+	rgID := connection.RgIDType(protectionGroupID)
 	err := r.updatePendingState(rgID)
 	if err != nil {
 		return nil, err
@@ -77,12 +77,13 @@ func (r *replication) GetStorageProtectionGroupStatus(ctx context.Context, prote
 
 // ExecuteAction queries client to execute on of supported replication actions
 func (r *replication) ExecuteAction(ctx context.Context, protectionGroupID string, actionType *csiext.ExecuteActionRequest_Action,
-	attributes map[string]string, remoteProtectionGroupID string, remoteAttributes map[string]string) (*csiext.ExecuteActionResponse, error) {
+	attributes map[string]string, remoteProtectionGroupID string, remoteAttributes map[string]string,
+) (*csiext.ExecuteActionResponse, error) {
 	tctx, cancel := context.WithTimeout(ctx, r.timeout)
 	defer cancel()
 	client := csiext.NewReplicationClient(r.conn)
 
-	var rgID = connection.RgIDType(protectionGroupID)
+	rgID := connection.RgIDType(protectionGroupID)
 	err := r.updatePendingState(rgID)
 	if err != nil {
 		return nil, err
@@ -150,7 +151,7 @@ func (r *replication) DeleteStorageProtectionGroup(ctx context.Context, groupID 
 	defer cancel()
 	client := csiext.NewReplicationClient(r.conn)
 
-	var rgID = connection.RgIDType(groupID)
+	rgID := connection.RgIDType(groupID)
 	err := r.updatePendingState(rgID)
 	if err != nil {
 		return err

--- a/pkg/csi-clients/replication/replication.go
+++ b/pkg/csi-clients/replication/replication.go
@@ -167,8 +167,5 @@ func (r *replication) DeleteStorageProtectionGroup(ctx context.Context, groupID 
 }
 
 func (r *replication) updatePendingState(rgID connection.RgIDType) error {
-	if err := rgID.CheckAndUpdatePendingState(&r.rgPendingState); err != nil {
-		return err
-	}
-	return nil
+	return rgID.CheckAndUpdatePendingState(&r.rgPendingState)
 }

--- a/pkg/csi-clients/replication/replication_fake.go
+++ b/pkg/csi-clients/replication/replication_fake.go
@@ -91,7 +91,8 @@ func NewFakeReplicationClient(contextPrefix string) MockReplication {
 
 // GetStorageProtectionGroupStatus mocks call
 func (m *MockReplication) GetStorageProtectionGroupStatus(ctx context.Context,
-	protectionGroupID string, attributes map[string]string) (*csiext.GetStorageProtectionGroupStatusResponse, error) {
+	protectionGroupID string, attributes map[string]string,
+) (*csiext.GetStorageProtectionGroupStatusResponse, error) {
 	defer m.ClearErrorAndCondition(false)
 	if err := m.injectedError.getError(); err != nil {
 		return nil, err
@@ -114,7 +115,8 @@ func (m *MockReplication) GetStorageProtectionGroupStatus(ctx context.Context,
 // ExecuteAction mocks call
 func (m *MockReplication) ExecuteAction(ctx context.Context, protectionGroupID string,
 	actionType *csiext.ExecuteActionRequest_Action, attributes map[string]string,
-	remoteProtectionGroupID string, remoteAttributes map[string]string) (*csiext.ExecuteActionResponse, error) {
+	remoteProtectionGroupID string, remoteAttributes map[string]string,
+) (*csiext.ExecuteActionResponse, error) {
 	defer m.ClearErrorAndCondition(false)
 	if err := m.injectedError.getError(); err != nil {
 		return nil, err
@@ -143,7 +145,8 @@ func (m *MockReplication) ExecuteAction(ctx context.Context, protectionGroupID s
 
 // CreateRemoteVolume mocks call
 func (m *MockReplication) CreateRemoteVolume(ctx context.Context, volumeHandle string,
-	params map[string]string) (*csiext.CreateRemoteVolumeResponse, error) {
+	params map[string]string,
+) (*csiext.CreateRemoteVolumeResponse, error) {
 	defer m.ClearErrorAndCondition(false)
 	if err := m.injectedError.getError(); err != nil {
 		return nil, err
@@ -163,7 +166,8 @@ func (m *MockReplication) CreateRemoteVolume(ctx context.Context, volumeHandle s
 
 // DeleteLocalVolume mocks call
 func (m *MockReplication) DeleteLocalVolume(ctx context.Context, volumeHandle string,
-	params map[string]string) (*csiext.DeleteLocalVolumeResponse, error) {
+	params map[string]string,
+) (*csiext.DeleteLocalVolumeResponse, error) {
 	defer m.ClearErrorAndCondition(false)
 	if err := m.injectedError.getError(); err != nil {
 		return nil, err
@@ -174,7 +178,8 @@ func (m *MockReplication) DeleteLocalVolume(ctx context.Context, volumeHandle st
 
 // CreateStorageProtectionGroup mocks call
 func (m *MockReplication) CreateStorageProtectionGroup(ctx context.Context, volumeHandle string,
-	params map[string]string) (*csiext.CreateStorageProtectionGroupResponse, error) {
+	params map[string]string,
+) (*csiext.CreateStorageProtectionGroupResponse, error) {
 	defer m.ClearErrorAndCondition(false)
 	if err := m.injectedError.getError(); err != nil {
 		return nil, err
@@ -211,7 +216,8 @@ func (m *MockReplication) CreateStorageProtectionGroup(ctx context.Context, volu
 
 // DeleteStorageProtectionGroup mocks call
 func (m *MockReplication) DeleteStorageProtectionGroup(ctx context.Context, groupID string,
-	groupAttributes map[string]string) error {
+	groupAttributes map[string]string,
+) error {
 	defer m.ClearErrorAndCondition(false)
 	if err := m.injectedError.getError(); err != nil {
 		return err

--- a/pkg/csi-clients/replication/replication_fake.go
+++ b/pkg/csi-clients/replication/replication_fake.go
@@ -90,8 +90,8 @@ func NewFakeReplicationClient(contextPrefix string) MockReplication {
 }
 
 // GetStorageProtectionGroupStatus mocks call
-func (m *MockReplication) GetStorageProtectionGroupStatus(ctx context.Context,
-	protectionGroupID string, attributes map[string]string,
+func (m *MockReplication) GetStorageProtectionGroupStatus(_ context.Context,
+	_ string, _ map[string]string,
 ) (*csiext.GetStorageProtectionGroupStatusResponse, error) {
 	defer m.ClearErrorAndCondition(false)
 	if err := m.injectedError.getError(); err != nil {
@@ -113,9 +113,9 @@ func (m *MockReplication) GetStorageProtectionGroupStatus(ctx context.Context,
 }
 
 // ExecuteAction mocks call
-func (m *MockReplication) ExecuteAction(ctx context.Context, protectionGroupID string,
-	actionType *csiext.ExecuteActionRequest_Action, attributes map[string]string,
-	remoteProtectionGroupID string, remoteAttributes map[string]string,
+func (m *MockReplication) ExecuteAction(_ context.Context, _ string,
+	actionType *csiext.ExecuteActionRequest_Action, _ map[string]string,
+	_ string, _ map[string]string,
 ) (*csiext.ExecuteActionResponse, error) {
 	defer m.ClearErrorAndCondition(false)
 	if err := m.injectedError.getError(); err != nil {
@@ -144,7 +144,7 @@ func (m *MockReplication) ExecuteAction(ctx context.Context, protectionGroupID s
 }
 
 // CreateRemoteVolume mocks call
-func (m *MockReplication) CreateRemoteVolume(ctx context.Context, volumeHandle string,
+func (m *MockReplication) CreateRemoteVolume(_ context.Context, volumeHandle string,
 	params map[string]string,
 ) (*csiext.CreateRemoteVolumeResponse, error) {
 	defer m.ClearErrorAndCondition(false)
@@ -165,8 +165,8 @@ func (m *MockReplication) CreateRemoteVolume(ctx context.Context, volumeHandle s
 }
 
 // DeleteLocalVolume mocks call
-func (m *MockReplication) DeleteLocalVolume(ctx context.Context, volumeHandle string,
-	params map[string]string,
+func (m *MockReplication) DeleteLocalVolume(_ context.Context, _ string,
+	_ map[string]string,
 ) (*csiext.DeleteLocalVolumeResponse, error) {
 	defer m.ClearErrorAndCondition(false)
 	if err := m.injectedError.getError(); err != nil {
@@ -177,8 +177,8 @@ func (m *MockReplication) DeleteLocalVolume(ctx context.Context, volumeHandle st
 }
 
 // CreateStorageProtectionGroup mocks call
-func (m *MockReplication) CreateStorageProtectionGroup(ctx context.Context, volumeHandle string,
-	params map[string]string,
+func (m *MockReplication) CreateStorageProtectionGroup(_ context.Context, _ string,
+	_ map[string]string,
 ) (*csiext.CreateStorageProtectionGroupResponse, error) {
 	defer m.ClearErrorAndCondition(false)
 	if err := m.injectedError.getError(); err != nil {
@@ -215,14 +215,11 @@ func (m *MockReplication) CreateStorageProtectionGroup(ctx context.Context, volu
 }
 
 // DeleteStorageProtectionGroup mocks call
-func (m *MockReplication) DeleteStorageProtectionGroup(ctx context.Context, groupID string,
-	groupAttributes map[string]string,
+func (m *MockReplication) DeleteStorageProtectionGroup(_ context.Context, _ string,
+	_ map[string]string,
 ) error {
 	defer m.ClearErrorAndCondition(false)
-	if err := m.injectedError.getError(); err != nil {
-		return err
-	}
-	return nil
+	return m.injectedError.getError()
 }
 
 // InjectError injects error

--- a/pkg/utils/noderescan.go
+++ b/pkg/utils/noderescan.go
@@ -3,10 +3,11 @@ package utils
 import (
 	"context"
 	"fmt"
-	"github.com/dell/gobrick/pkg/scsi"
-	log "github.com/sirupsen/logrus"
 	"os"
 	"strconv"
+
+	"github.com/dell/gobrick/pkg/scsi"
+	log "github.com/sirupsen/logrus"
 )
 
 // RescanNode is called to rescan the nodes
@@ -30,7 +31,8 @@ func rescanSCSIHostAll(ctx context.Context) error {
 			Host:    strconv.Itoa(host),
 			Lun:     "-",
 			Channel: "-",
-			Target:  "-"}
+			Target:  "-",
+		}
 		err := scsiHost.RescanSCSIHostByHCTL(ctx, hctl)
 		if err != nil {
 			log.Error(ctx, err.Error())

--- a/pkg/utils/noderescan.go
+++ b/pkg/utils/noderescan.go
@@ -1,3 +1,17 @@
+/*
+ Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
 package utils
 
 import (

--- a/repctl/cmd/repctl/main.go
+++ b/repctl/cmd/repctl/main.go
@@ -61,7 +61,7 @@ func main() {
 		Use:     "repctl",
 		Short:   "repctl is CLI tool for managing replication in Kubernetes",
 		Long:    "repctl is CLI tool for managing replication in Kubernetes",
-		Version: "v1.5.0",
+		Version: "v1.6.0",
 
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			metadata.Init(viper.GetString(config.ReplicationPrefix))

--- a/repctl/pkg/cmd/cluster.go
+++ b/repctl/pkg/cmd/cluster.go
@@ -473,7 +473,7 @@ func getClustersFolderPath(path string) (string, error) {
 		return "", fmt.Errorf("can't get User home group: %s", err.Error())
 	}
 
-	err = os.MkdirAll(curUserPath, 0750)
+	err = os.MkdirAll(curUserPath, 0o750)
 	if err != nil {
 		return "", fmt.Errorf("can't generate clusters folder: %s", err.Error())
 	}
@@ -486,7 +486,7 @@ func generateConfigsFromSA(mc *k8s.MultiClusterConfigurator, clusterIDs []string
 	log.Print("Generating config maps from existing service accounts")
 	namespace := "dell-replication-controller"
 
-	err := os.MkdirAll("/tmp/repctl", 0750)
+	err := os.MkdirAll("/tmp/repctl", 0o750)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create tmp dir: %s", err.Error())
 	}
@@ -497,7 +497,7 @@ func generateConfigsFromSA(mc *k8s.MultiClusterConfigurator, clusterIDs []string
 		return nil, fmt.Errorf("failed to read embedded script: %s", err.Error())
 	}
 
-	err = os.WriteFile("/tmp/repctl/gen_kubeconfig.sh", fileData, 0600) // #nosec G303
+	err = os.WriteFile("/tmp/repctl/gen_kubeconfig.sh", fileData, 0o600) // #nosec G303
 	if err != nil {
 		return nil, fmt.Errorf("failed to write embedded script: %s", err.Error())
 	}
@@ -508,7 +508,7 @@ func generateConfigsFromSA(mc *k8s.MultiClusterConfigurator, clusterIDs []string
 		return nil, fmt.Errorf("failed to read embedded config template: %s", err.Error())
 	}
 
-	err = os.WriteFile("/tmp/repctl/config-placeholder", fileData, 0600) // #nosec G303
+	err = os.WriteFile("/tmp/repctl/config-placeholder", fileData, 0o600) // #nosec G303
 	if err != nil {
 		return nil, fmt.Errorf("failed to write embedded config template: %s", err.Error())
 	}

--- a/repctl/pkg/cmd/cluster.go
+++ b/repctl/pkg/cmd/cluster.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2022-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/repctl/pkg/cmd/create.go
+++ b/repctl/pkg/cmd/create.go
@@ -185,7 +185,6 @@ associated with a ReplicationGroup or a single PersistentVolume
 If you don't encounter any issues in the dry-run, then you can
 re-run the command by removing the dry run flag.`,
 		Run: func(cmd *cobra.Command, args []string) {
-
 			tgtNamespace := viper.GetString("target-namespace")
 			dryRun := viper.GetBool("dry-run")
 			rgName := viper.GetString(config.ReplicationGroup)
@@ -215,7 +214,6 @@ re-run the command by removing the dry run flag.`,
 			if err != nil {
 				log.Fatalf("create pvc: %s", err.Error())
 			}
-
 		},
 	}
 

--- a/repctl/pkg/cmd/create_test.go
+++ b/repctl/pkg/cmd/create_test.go
@@ -129,7 +129,6 @@ func (suite *CreateTestSuite) TestCreateSCs() {
 
 	err := createSCs(config, clusters, false)
 	suite.NoError(err)
-
 }
 
 func TestCreateTestSuite(t *testing.T) {

--- a/repctl/pkg/cmd/create_test.go
+++ b/repctl/pkg/cmd/create_test.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2021-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/repctl/pkg/cmd/failover.go
+++ b/repctl/pkg/cmd/failover.go
@@ -283,7 +283,6 @@ func failoverToCluster(configFolder, inputTargetCluster, rgName string, unplanne
 }
 
 func waitForStateToUpdate(rgName string, cluster k8s.ClusterInterface, repllinkstate repv1.ReplicationLinkState) bool {
-
 	ret := make(chan bool)
 	go func() {
 		log.Print("Waiting for action to complete ...")

--- a/repctl/pkg/cmd/migrate.go
+++ b/repctl/pkg/cmd/migrate.go
@@ -34,10 +34,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var migrationPref = "migration.storage.dell.com"
-var migrationAnnotation = ""
-var migrationNS = ""
-var yes = false
+var (
+	migrationPref       = "migration.storage.dell.com"
+	migrationAnnotation = ""
+	migrationNS         = ""
+	yes                 = false
+)
 
 // GetMigrateCommand returns 'edit' cobra command
 func GetMigrateCommand() *cobra.Command {
@@ -407,7 +409,6 @@ func waitForPodToBeReady(podName string, podNS string, cluster k8s.ClusterInterf
 							return
 						}
 					}
-
 				}
 			}
 		}
@@ -492,7 +493,6 @@ func migrateMG(configFolder, resource string, resName string, targetNS string, w
 		go migrateArray(context.Background(), cluster, resName, targetNS, wg, wait)
 	}
 	wg.Wait()
-
 }
 
 func migrateArray(ctx context.Context, cluster k8s.ClusterInterface, mgName string, targetNS string, wg *sync.WaitGroup, wait bool) {
@@ -512,7 +512,7 @@ func migrateArray(ctx context.Context, cluster k8s.ClusterInterface, mgName stri
 		log.Error(err, "unable to update mg")
 		os.Exit(1)
 	}
-	//Command exit criteria
+	// Command exit criteria
 	if wait {
 		done := waitForArrayMigration(mgName, cluster)
 		if done {

--- a/repctl/pkg/k8s/cluster.go
+++ b/repctl/pkg/k8s/cluster.go
@@ -305,7 +305,8 @@ func (c *Cluster) GetPersistentVolumeClaim(ctx context.Context, nsName string, p
 
 // FilterPersistentVolumeClaims returns filtered list of all persistent volume claim objects that are currently in cluster
 func (c *Cluster) FilterPersistentVolumeClaims(ctx context.Context, namespace, remoteClusterID,
-	remoteNamespace, rgName string) (*types.PersistentVolumeClaimList, error) {
+	remoteNamespace, rgName string,
+) (*types.PersistentVolumeClaimList, error) {
 	matchingLabels := make(map[string]string)
 	if remoteClusterID != "" {
 		matchingLabels[metadata.RemoteClusterID] = remoteClusterID
@@ -332,7 +333,8 @@ func (c *Cluster) FilterPersistentVolumeClaims(ctx context.Context, namespace, r
 
 // CreatePersistentVolumeClaimsFromPVs uses list of persistent volume to create remote PVCs
 func (c *Cluster) CreatePersistentVolumeClaimsFromPVs(ctx context.Context, namespace string,
-	pvList []types.PersistentVolume, prefix string, dryRun bool) error {
+	pvList []types.PersistentVolume, prefix string, dryRun bool,
+) error {
 	// go through the PV list and create PVC objects
 	for _, pv := range pvList {
 		// First check if we have an existing PVC
@@ -690,7 +692,6 @@ func (c *Cluster) GetStatefulSet(ctx context.Context, nsName string, stsName str
 
 // FilterPods returns filtered list of pod, managed by given sts
 func (c *Cluster) FilterPods(ctx context.Context, namespace string, stsName string) (*v1.PodList, error) {
-
 	podList, err := c.ListPods(ctx, client.InNamespace(namespace))
 	if err != nil {
 		return nil, err

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -29,7 +29,7 @@ source "$SCRIPTDIR"/common.sh
 
 if [ ! -d "$MODULEDIR/helm-charts" ]; then
   if  [ ! -d "$SCRIPTDIR/helm-charts" ]; then
-    git clone --quiet -c advice.detachedHead=false -b csm-replication-1.5.0 https://github.com/dell/helm-charts
+    git clone --quiet -c advice.detachedHead=false -b csm-replication-1.6.0 https://github.com/dell/helm-charts
   fi
   mv helm-charts $MODULEDIR
 else

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -21,23 +21,12 @@ MODE="install"
 NS="dell-replication-controller"
 RELEASE="replication"
 MODULE="csm-replication"
+HELMCHARTVERSION="csm-replication-1.6.0"
 
 # export the name of the debug log, so child processes will see it
 export DEBUGLOG="${SCRIPTDIR}/install-debug.log"
 
 source "$SCRIPTDIR"/common.sh
-
-if [ ! -d "$MODULEDIR/helm-charts" ]; then
-  if  [ ! -d "$SCRIPTDIR/helm-charts" ]; then
-    git clone --quiet -c advice.detachedHead=false -b csm-replication-1.6.0 https://github.com/dell/helm-charts
-  fi
-  mv helm-charts $MODULEDIR
-else
-  if [  -d "$SCRIPTDIR/helm-charts" ]; then
-    rm -rf $SCRIPTDIR/helm-charts
-  fi
-fi
-MODULEDIR="${SCRIPTDIR}/../helm-charts/charts"
 
 if [ -f "${DEBUGLOG}" ]; then
   rm -f "${DEBUGLOG}"
@@ -55,6 +44,7 @@ function usage() {
 
   decho "  Optional"
   decho "  --upgrade                                Perform an upgrade, default is false"
+  decho "  --helm-charts-version                    Pass the helm chart version"
   decho "  -h                                       Help"
   decho
 
@@ -168,11 +158,13 @@ function kubectl_safe() {
     exit $exitcode
   fi
 }
+
 function found_error() {
   for N in "$@"; do
     ERRORS+=("${N}")
   done
 }
+
 # verify namespace
 function verify_namespace() {
   log step "Verifying that required namespaces have been created"
@@ -188,7 +180,6 @@ function verify_namespace() {
     log passed
   done
 }
-
 
 # waitOnRunning
 # will wait, for a timeout period, for a number of pods to go into Running state within a namespace
@@ -231,7 +222,6 @@ function waitOnRunning() {
   return 0
 }
 
-#
 # verify_kubernetes
 # will run a module specific function to verify environmental requirements
 function verify_kubernetes() {
@@ -251,7 +241,11 @@ while getopts ":h-:" optchar; do
     upgrade)
       MODE="upgrade"
       ;;
-      # VALUES
+    helm-charts-version)
+      HELMCHARTVERSION="${!OPTIND}"
+      OPTIND=$((OPTIND + 1))
+      ;;
+    # VALUES
     values)
       VALUES="${!OPTIND}"
       OPTIND=$((OPTIND + 1))
@@ -276,6 +270,18 @@ while getopts ":h-:" optchar; do
     ;;
   esac
 done
+
+if [ ! -d "$MODULEDIR/helm-charts" ]; then
+  if  [ ! -d "$SCRIPTDIR/helm-charts" ]; then
+    git clone --quiet -c advice.detachedHead=false -b $HELMCHARTVERSION https://github.com/dell/helm-charts
+  fi
+  mv helm-charts $MODULEDIR
+else
+  if [  -d "$SCRIPTDIR/helm-charts" ]; then
+    rm -rf $SCRIPTDIR/helm-charts
+  fi
+fi
+MODULEDIR="${SCRIPTDIR}/../helm-charts/charts"
 
 # make sure kubectl is available
 kubectl --help >&/dev/null || {

--- a/test/e2e-framework/controller_integration_test.go
+++ b/test/e2e-framework/controller_integration_test.go
@@ -54,7 +54,7 @@ type RealControllerUtils struct {
 
 func (suite *ReplicationControllerTestSuite) Init() {
 	utils.InitializeSchemes()
-	//Setting driver configurations, update here to run against any driver
+	// Setting driver configurations, update here to run against any driver
 	suite.driver = utils.Driver{
 		DriverName:   "hostpath.csi.k8s.io",
 		StorageClass: "hostpath-del",
@@ -170,7 +170,7 @@ func (suite *ReplicationControllerTestSuite) createLocalPVC() error {
 		annotations[controllers.ReplicationGroup] = LocalRg
 		pvcObj.SetAnnotations(annotations)
 
-		//Adding labels
+		// Adding labels
 		labels := make(map[string]string)
 		labels[controllers.RemoteClusterID] = "lglap066"
 		labels[controllers.DriverName] = suite.driver.DriverName
@@ -227,7 +227,6 @@ func (suite *ReplicationControllerTestSuite) createLocalRG() error {
 	err := suite.realUtils.KubernetesClient.Get(ctx, types.NamespacedName{
 		Name: LocalRg,
 	}, &newRG)
-
 	if err != nil {
 		err := suite.realUtils.KubernetesClient.Create(ctx, &newRG)
 		if err != nil {
@@ -284,7 +283,7 @@ func (suite *ReplicationControllerTestSuite) updateLocalPV(name string) error {
 	annotations[controllers.ReplicationGroup] = LocalRg
 	pv.SetAnnotations(annotations)
 
-	//Adding labels
+	// Adding labels
 	labels := make(map[string]string)
 	labels[controllers.RemoteClusterID] = "lglap066"
 	labels[controllers.DriverName] = suite.driver.DriverName

--- a/test/e2e-framework/fake-client/fake-client.go
+++ b/test/e2e-framework/fake-client/fake-client.go
@@ -89,7 +89,7 @@ func NewFakeClient(initialObjects []runtime.Object, errorInjector errorInjector)
 }
 
 // Get finds object and puts it in client.Object obj argument
-func (f Client) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+func (f Client) Get(_ context.Context, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
 	if f.errorInjector != nil {
 		if err := f.errorInjector.shouldFail("Get", obj); err != nil {
 			return err
@@ -124,7 +124,7 @@ func (f Client) Get(ctx context.Context, key client.ObjectKey, obj client.Object
 }
 
 // List list all requested items in fake cluster
-func (f Client) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+func (f Client) List(_ context.Context, list client.ObjectList, opts ...client.ListOption) error {
 	if f.errorInjector != nil {
 		if err := f.errorInjector.shouldFail("List", list); err != nil {
 			return err
@@ -208,7 +208,7 @@ func (f *Client) listReplicationGroup(list *repv1.DellCSIReplicationGroupList, o
 }
 
 // Create creates new object in fake cluster by putting it in map
-func (f Client) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+func (f Client) Create(_ context.Context, obj client.Object, _ ...client.CreateOption) error {
 	if f.errorInjector != nil {
 		if err := f.errorInjector.shouldFail("Create", obj); err != nil {
 			return err
@@ -235,7 +235,7 @@ func (f Client) Create(ctx context.Context, obj client.Object, opts ...client.Cr
 }
 
 // Delete deletes existing object in fake cluster by removing it from map
-func (f Client) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+func (f Client) Delete(_ context.Context, obj client.Object, opts ...client.DeleteOption) error {
 	if len(opts) > 0 {
 		return fmt.Errorf("delete options are not supported")
 	}
@@ -266,7 +266,7 @@ func (f Client) Delete(ctx context.Context, obj client.Object, opts ...client.De
 }
 
 // Update updates object in fake k8s cluster
-func (f Client) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+func (f Client) Update(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
 	if f.errorInjector != nil {
 		if err := f.errorInjector.shouldFail("Update", obj); err != nil {
 			return err
@@ -293,12 +293,12 @@ func (f Client) Update(ctx context.Context, obj client.Object, opts ...client.Up
 }
 
 // Patch patches the given obj in the Kubernetes cluster
-func (f Client) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+func (f Client) Patch(_ context.Context, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
 	panic("implement me")
 }
 
 // DeleteAllOf deletes all objects of the given type matching the given options
-func (f Client) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+func (f Client) DeleteAllOf(_ context.Context, _ client.Object, _ ...client.DeleteAllOfOption) error {
 	panic("implement me")
 }
 
@@ -320,31 +320,31 @@ func (f Client) RESTMapper() meta.RESTMapper {
 
 // SubResource returns a subresource client for the named subResource.
 // TODO: Implement
-func (f Client) SubResource(subResource string) client.SubResourceClient {
+func (f Client) SubResource(_ string) client.SubResourceClient {
 	return f.SubResourceClient
 }
 
 // Create saves the subResource object in the Kubernetes cluster.
 // TODO: Implement
-func (f SubResourceClient) Create(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceCreateOption) error {
+func (f SubResourceClient) Create(_ context.Context, _ client.Object, _ client.Object, _ ...client.SubResourceCreateOption) error {
 	panic("implement me")
 }
 
 // Update updates the fields corresponding to the status subresource for the
 // given obj.
 // TODO: Implement
-func (f SubResourceClient) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+func (f SubResourceClient) Update(_ context.Context, _ client.Object, _ ...client.SubResourceUpdateOption) error {
 	panic("implement me")
 }
 
 // Patch patches the given object's subresource.
 // TODO: Implement
-func (f SubResourceClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption) error {
+func (f SubResourceClient) Patch(_ context.Context, _ client.Object, _ client.Patch, _ ...client.SubResourcePatchOption) error {
 	panic("implement me")
 }
 
 // Get retrieves a subResource for the given obj object from the Kubernetes Cluster.
 // TODO: Implement
-func (f SubResourceClient) Get(ctx context.Context, obj client.Object, subResource client.Object, opts ...client.SubResourceGetOption) error {
+func (f SubResourceClient) Get(_ context.Context, _ client.Object, _ client.Object, _ ...client.SubResourceGetOption) error {
 	panic("implement me")
 }

--- a/test/e2e-framework/fake-client/fake-client.go
+++ b/test/e2e-framework/fake-client/fake-client.go
@@ -53,8 +53,7 @@ type Client struct {
 }
 
 // SubResourceClient is a fake k8s subresource client
-type SubResourceClient struct {
-}
+type SubResourceClient struct{}
 
 func getKey(obj runtime.Object) (storageKey, error) {
 	accessor, err := meta.Accessor(obj)

--- a/test/e2e-framework/fake_integration_test.go
+++ b/test/e2e-framework/fake_integration_test.go
@@ -19,6 +19,7 @@ package e2e_framework_test
 import (
 	"context"
 	"sync"
+	"testing"
 	"time"
 
 	repv1 "github.com/dell/csm-replication/api/v1"
@@ -38,8 +39,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
-
-	"testing"
 
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -228,7 +227,7 @@ func (suite *FakeReplicationTestSuite) getTypicalPVC() *corev1.PersistentVolumeC
 }
 
 func (suite *FakeReplicationTestSuite) getTypicalVolAttributes() map[string]string {
-	//creating fake PV to use with our fake PVC
+	// creating fake PV to use with our fake PVC
 	volumeAttributes := map[string]string{
 		"CapacityGB": "3.00",
 		"param1":     "val1",

--- a/test/e2e-framework/sidecar/sidecar_integration_test.go
+++ b/test/e2e-framework/sidecar/sidecar_integration_test.go
@@ -358,7 +358,7 @@ func (ss *SidecarTestSuite) SetupSuite() {
 	ss.runManager()
 	utilruntime.Must(ss.createClient())
 	utilruntime.Must(ss.verifyStorageClass())
-	//utilruntime.Must(ss.createTestNamespaceIfNotExist())
+	// utilruntime.Must(ss.createTestNamespaceIfNotExist())
 }
 
 func (ss *SidecarTestSuite) waitForPVCProtectionComplete(ctx context.Context, claim *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error) {

--- a/test/e2e-framework/sidecar/sidecar_integration_test.go
+++ b/test/e2e-framework/sidecar/sidecar_integration_test.go
@@ -335,12 +335,10 @@ func (ss *SidecarTestSuite) createTestNamespaceIfNotExist() error {
 				},
 			}
 			return ss.client.Create(ss.ctx, ns)
-		} else {
-			return err
 		}
-	} else {
-		ss.namespace = ns.Name
+		return err
 	}
+	ss.namespace = ns.Name
 	return nil
 }
 
@@ -361,7 +359,7 @@ func (ss *SidecarTestSuite) SetupSuite() {
 	// utilruntime.Must(ss.createTestNamespaceIfNotExist())
 }
 
-func (ss *SidecarTestSuite) waitForPVCProtectionComplete(ctx context.Context, claim *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error) {
+func (ss *SidecarTestSuite) waitForPVCProtectionComplete(ctx context.Context, _ *v1.PersistentVolumeClaim) (*v1.PersistentVolumeClaim, error) {
 	errorCh := make(chan error)
 	pvc := new(v1.PersistentVolumeClaim)
 	go func() {

--- a/test/e2e-framework/sidecar_integration_test.go
+++ b/test/e2e-framework/sidecar_integration_test.go
@@ -143,9 +143,9 @@ func (suite *ReplicationTestSuite) runReplicationManager() {
 func (suite *ReplicationTestSuite) TestCreatePVC() {
 	pvc, err := suite.createPVC()
 	suite.T().Log("waiting for the reconciliation to complete")
-	time.Sleep(10 * time.Second) //wait for few seconds for the reconciliation to happen
+	time.Sleep(10 * time.Second) // wait for few seconds for the reconciliation to happen
 
-	//validate created PVC
+	// validate created PVC
 	assert.NoError(suite.T(), err, "PVC Created successfully")
 	assert.NotNil(suite.T(), pvc)
 
@@ -211,7 +211,7 @@ func (suite *ReplicationTestSuite) performAction(action string, expectedState st
 
 	time.Sleep(10 * time.Second)
 
-	//validate the RG for the updated action
+	// validate the RG for the updated action
 	rg = &repv1.DellCSIReplicationGroup{}
 	err = suite.realUtils.KubernetesClient.Get(context.Background(), types.NamespacedName{
 		Name: pvc.Annotations[controllers.ReplicationGroup],
@@ -237,11 +237,11 @@ func (suite *ReplicationTestSuite) TearDownTestSuite() {
 		pvc, err := suite.getLocalPVCFromCluster()
 		assert.NoError(suite.T(), err, "Fetched PVC successfully")
 
-		//Delete PVC
+		// Delete PVC
 		err = suite.realUtils.KubernetesClient.Delete(ctx, pvc)
 		assert.NoError(suite.T(), err, "PVC Deleted successfully")
 
-		//Delete RG
+		// Delete RG
 		rg := &repv1.DellCSIReplicationGroup{}
 		err = suite.realUtils.KubernetesClient.Get(context.Background(), types.NamespacedName{
 			Name: pvc.Annotations[controllers.ReplicationGroup],

--- a/test/e2e-framework/utils/utils.go
+++ b/test/e2e-framework/utils/utils.go
@@ -125,7 +125,6 @@ const PVCName = "test-pvc"
 
 // InitializeSchemes inits client-go and replication v1 schemes
 func InitializeSchemes() {
-
 	utilruntime.Must(clientgoscheme.AddToScheme(Scheme))
 	utilruntime.Must(repv1.AddToScheme(Scheme))
 	// +kubebuilder:scaffold:scheme
@@ -329,7 +328,8 @@ func GetNonReplicationEnabledSC(provisionerName, scName string) *storagev1.Stora
 
 // GetRGObj returns DellCSIReplicationGroup testing object
 func GetRGObj(name, driverName, remoteClusterID, pgID, remotePGID string, params,
-	remoteParams map[string]string) *repv1.DellCSIReplicationGroup {
+	remoteParams map[string]string,
+) *repv1.DellCSIReplicationGroup {
 	replicationGroup := repv1.DellCSIReplicationGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,

--- a/test/mock-server/server/server.go
+++ b/test/mock-server/server/server.go
@@ -20,12 +20,11 @@ import (
 	"bytes"
 	context2 "context"
 	"encoding/json"
+	"fmt"
 	"io"
+	"net/http"
 
 	"github.com/dell/dell-csi-extensions/migration"
-
-	"fmt"
-	"net/http"
 
 	commonext "github.com/dell/dell-csi-extensions/common"
 	"github.com/dell/dell-csi-extensions/replication"

--- a/test/mock-server/server/server.go
+++ b/test/mock-server/server/server.go
@@ -35,7 +35,7 @@ import (
 type Replication struct{}
 
 // VolumeMigrate - mocks Migrate function
-func (s *Replication) VolumeMigrate(ctx context2.Context, request *migration.VolumeMigrateRequest) (*migration.VolumeMigrateResponse, error) {
+func (s *Replication) VolumeMigrate(_ context2.Context, _ *migration.VolumeMigrateRequest) (*migration.VolumeMigrateResponse, error) {
 	rep := &migration.VolumeMigrateResponse{
 		MigratedVolume: &migration.Volume{
 			CapacityBytes: 3221225472,
@@ -56,7 +56,7 @@ func (s *Replication) VolumeMigrate(ctx context2.Context, request *migration.Vol
 }
 
 // GetMigrationCapabilities - mocks GetMigrationCapabilities func
-func (s *Replication) GetMigrationCapabilities(ctx context2.Context, request *migration.GetMigrationCapabilityRequest) (*migration.GetMigrationCapabilityResponse, error) {
+func (s *Replication) GetMigrationCapabilities(_ context2.Context, _ *migration.GetMigrationCapabilityRequest) (*migration.GetMigrationCapabilityResponse, error) {
 	return &migration.GetMigrationCapabilityResponse{
 		Capabilities: []*migration.MigrationCapability{
 			{
@@ -85,14 +85,14 @@ func (s *Replication) GetMigrationCapabilities(ctx context2.Context, request *mi
 }
 
 // ProbeController calls stub for ProbeController
-func (s *Replication) ProbeController(ctx context.Context, in *commonext.ProbeControllerRequest) (*commonext.ProbeControllerResponse, error) {
+func (s *Replication) ProbeController(_ context.Context, in *commonext.ProbeControllerRequest) (*commonext.ProbeControllerResponse, error) {
 	out := &commonext.ProbeControllerResponse{}
 	err := FindStub("Replication", "ProbeController", in, out)
 	return out, err
 }
 
 // GetReplicationCapabilities calls stub for GetReplicationCapabilities
-func (s *Replication) GetReplicationCapabilities(ctx context.Context, in *replication.GetReplicationCapabilityRequest) (*replication.GetReplicationCapabilityResponse, error) {
+func (s *Replication) GetReplicationCapabilities(_ context.Context, in *replication.GetReplicationCapabilityRequest) (*replication.GetReplicationCapabilityResponse, error) {
 	out := &replication.GetReplicationCapabilityResponse{}
 	outTemp := make(map[string][]int)
 	err := FindStub("Replication", "GetReplicationCapabilities", in, &outTemp)
@@ -116,42 +116,42 @@ func (s *Replication) GetReplicationCapabilities(ctx context.Context, in *replic
 }
 
 // CreateStorageProtectionGroup calls stub for CreateStorageProtectionGroup
-func (s *Replication) CreateStorageProtectionGroup(ctx context.Context, in *replication.CreateStorageProtectionGroupRequest) (*replication.CreateStorageProtectionGroupResponse, error) {
+func (s *Replication) CreateStorageProtectionGroup(_ context.Context, in *replication.CreateStorageProtectionGroupRequest) (*replication.CreateStorageProtectionGroupResponse, error) {
 	out := &replication.CreateStorageProtectionGroupResponse{}
 	err := FindStub("Replication", "CreateStorageProtectionGroup", in, out)
 	return out, err
 }
 
 // CreateRemoteVolume calls stub for CreateRemoteVolume
-func (s *Replication) CreateRemoteVolume(ctx context.Context, in *replication.CreateRemoteVolumeRequest) (*replication.CreateRemoteVolumeResponse, error) {
+func (s *Replication) CreateRemoteVolume(_ context.Context, in *replication.CreateRemoteVolumeRequest) (*replication.CreateRemoteVolumeResponse, error) {
 	out := &replication.CreateRemoteVolumeResponse{}
 	err := FindStub("Replication", "CreateRemoteVolume", in, out)
 	return out, err
 }
 
 // DeleteLocalVolume calls stub for DeleteLocalVolume
-func (s *Replication) DeleteLocalVolume(ctx context.Context, in *replication.DeleteLocalVolumeRequest) (*replication.DeleteLocalVolumeResponse, error) {
+func (s *Replication) DeleteLocalVolume(_ context.Context, in *replication.DeleteLocalVolumeRequest) (*replication.DeleteLocalVolumeResponse, error) {
 	out := &replication.DeleteLocalVolumeResponse{}
 	err := FindStub("Replication", "DeleteLocalVolume", in, out)
 	return out, err
 }
 
 // DeleteStorageProtectionGroup calls stub for DeleteStorageProtectionGroup
-func (s *Replication) DeleteStorageProtectionGroup(ctx context.Context, in *replication.DeleteStorageProtectionGroupRequest) (*replication.DeleteStorageProtectionGroupResponse, error) {
+func (s *Replication) DeleteStorageProtectionGroup(_ context.Context, in *replication.DeleteStorageProtectionGroupRequest) (*replication.DeleteStorageProtectionGroupResponse, error) {
 	out := &replication.DeleteStorageProtectionGroupResponse{}
 	err := FindStub("Replication", "DeleteStorageProtectionGroup", in, out)
 	return out, err
 }
 
 // GetStorageProtectionGroupStatus calls stub for GetStorageProtectionGroupStatus
-func (s *Replication) GetStorageProtectionGroupStatus(ctx context.Context, in *replication.GetStorageProtectionGroupStatusRequest) (*replication.GetStorageProtectionGroupStatusResponse, error) {
+func (s *Replication) GetStorageProtectionGroupStatus(_ context.Context, in *replication.GetStorageProtectionGroupStatusRequest) (*replication.GetStorageProtectionGroupStatusResponse, error) {
 	out := &replication.GetStorageProtectionGroupStatusResponse{}
 	err := FindStub("Replication", "GetStorageProtectionGroupStatus", in, out)
 	return out, err
 }
 
 // ExecuteAction calls stub for ExecuteAction
-func (s *Replication) ExecuteAction(ctx context.Context, in *replication.ExecuteActionRequest) (*replication.ExecuteActionResponse, error) {
+func (s *Replication) ExecuteAction(_ context.Context, in *replication.ExecuteActionRequest) (*replication.ExecuteActionResponse, error) {
 	out := &replication.ExecuteActionResponse{}
 	err := FindStub("Replication", "ExecuteAction", in, out)
 	return out, err

--- a/test/mock-server/stub/stub.go
+++ b/test/mock-server/stub/stub.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2021 Dell Inc. or its subsidiaries. All Rights Reserved.
+Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -134,7 +134,7 @@ func addStub(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func listStub(w http.ResponseWriter, r *http.Request) {
+func listStub(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	err := json.NewEncoder(w).Encode(allStub())
 	if err != nil {
@@ -206,7 +206,7 @@ func handleFindStub(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-func handleClearStub(w http.ResponseWriter, r *http.Request) {
+func handleClearStub(w http.ResponseWriter, _ *http.Request) {
 	clearStorage()
 	_, err := w.Write([]byte("OK"))
 	if err != nil {

--- a/test/mock-server/stub/stub_test.go
+++ b/test/mock-server/stub/stub_test.go
@@ -114,7 +114,8 @@ func TestStub(t *testing.T) {
 			},
 			handler: handleFindStub,
 			expect:  "{\"data\":{\"hello\":\"world\"},\"error\":\"\"}\n",
-		}, {
+		},
+		{
 			name: "add stub matches regex",
 			mock: func() *http.Request {
 				payload := `{
@@ -135,7 +136,8 @@ func TestStub(t *testing.T) {
 			},
 			handler: addStub,
 			expect:  "Success add stub",
-		}, {
+		},
+		{
 			name: "find stub matches regex",
 			mock: func() *http.Request {
 				payload := `{
@@ -149,7 +151,8 @@ func TestStub(t *testing.T) {
 			},
 			handler: handleFindStub,
 			expect:  "{\"data\":{\"reply\":\"OK\"},\"error\":\"\"}\n",
-		}, {
+		},
+		{
 			name: "error find stub contains",
 			mock: func() *http.Request {
 				payload := `{
@@ -165,7 +168,8 @@ func TestStub(t *testing.T) {
 			},
 			handler: handleFindStub,
 			expect:  "Can't find stub \n\nService: Testing \n\nMethod: TestMethod \n\nInput\n\n{\n\tfield1: hello field1\n\tfield2: hello field2\n\tfield3: hello field4\n}\n\nClosest Match \n\ncontains:{\n\tfield1: hello field1\n\tfield3: hello field3\n}",
-		}, {
+		},
+		{
 			name: "error find stub equals",
 			mock: func() *http.Request {
 				payload := `{"service":"Testing","method":"TestMethod","data":{"Hello":"World"}}`

--- a/test/mock-server/stub/stub_test.go
+++ b/test/mock-server/stub/stub_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2021 Dell Inc. or its subsidiaries. All Rights Reserved.
+Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
# Description

- Updated controller version to 1.6.0 for deployment via repctl.
- Updated install script to accept optional helm-charts branch.
- Fixed golangci-lint errors and warnings.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/885 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?

Tested install script with/without helm branch flag and confirmed that the pods deployed as expected.
bash scripts/install.sh --values ./myvalues.yaml --helm-charts-version release-v1.8.0