### PR TITLE
Only initialize scheme once during unit tests

### DIFF
--- a/test/e2e-framework/utils/utils.go
+++ b/test/e2e-framework/utils/utils.go
@@ -120,13 +120,19 @@ var MockServer *grpc.Server
 // Scheme runtime Scheme
 var Scheme = runtime.NewScheme()
 
+// Only initialize schemes once to prevent race condition during testing
+var schemesInitialized bool = false
+
 // PVCName name of testing PVC
 const PVCName = "test-pvc"
 
 // InitializeSchemes inits client-go and replication v1 schemes
 func InitializeSchemes() {
-	utilruntime.Must(clientgoscheme.AddToScheme(Scheme))
-	utilruntime.Must(repv1.AddToScheme(Scheme))
+	if !schemesInitialized {
+		utilruntime.Must(clientgoscheme.AddToScheme(Scheme))
+		utilruntime.Must(repv1.AddToScheme(Scheme))
+		schemesInitialized = true
+	}
 	// +kubebuilder:scaffold:scheme
 }
 

--- a/test/e2e-framework/utils/utils.go
+++ b/test/e2e-framework/utils/utils.go
@@ -121,7 +121,7 @@ var MockServer *grpc.Server
 var Scheme = runtime.NewScheme()
 
 // Only initialize schemes once to prevent race condition during testing
-var schemesInitialized bool = false
+var schemesInitialized = false
 
 // PVCName name of testing PVC
 const PVCName = "test-pvc"


### PR DESCRIPTION
# Description
Only initialize scheme once during unit tests to prevent a race condition.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ran the unit tests
