### PR TITLE
Point to the correct release version `1.7.0`

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -21,7 +21,7 @@ MODE="install"
 NS="dell-replication-controller"
 RELEASE="replication"
 MODULE="csm-replication"
-HELMCHARTVERSION="csm-replication-1.6.0"
+HELMCHARTVERSION="csm-replication-1.7.0"
 
 # export the name of the debug log, so child processes will see it
 export DEBUGLOG="${SCRIPTDIR}/install-debug.log"


### PR DESCRIPTION
# Description
The 1.7.0 script point to an older version of the helm-chart.

This will have to bumped next time

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Tested at Boeing
