### PR TITLE
Build repctl with static lib

### DIFF
--- a/repctl/Makefile
+++ b/repctl/Makefile
@@ -3,7 +3,7 @@ all: build
 build:
 	cp -f ../scripts/gen_kubeconfig.sh ./pkg/cmd/scripts/gen_kubeconfig.sh
 	cp -f ../scripts/config-placeholder ./pkg/cmd/scripts/config-placeholder
-	go build ./cmd/repctl
+	CGO_ENABLED=1 CGO_LDFLAGS="-static" go build ./cmd/repctl
 
 test:
 	cp ../scripts/gen_kubeconfig.sh ./pkg/cmd/scripts/gen_kubeconfig.sh


### PR DESCRIPTION
Otherwise it crashes on certain distro due to missing GLIBC dependencies

# Description
During a PoC we could not use the distributed `repctl` and had to rebuild it. Static libs are <3
# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Built on my Fedora 40 tested on a RHEL 8.x
