### PR TITLE
Remap all the pvcs within the specified replication group

### DIFF
--- a/scripts/pvcremap.go
+++ b/scripts/pvcremap.go
@@ -31,8 +31,6 @@ func main() {
 		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
 	}
 	rgNamePtr := flag.String("rg", "", "id for the RG")
-	// namespacePtr := flag.String("n", "", "namespace for the PVC to be rebound")
-	// targetPtr := flag.String("t", "", "original or replicated indicating the desired target for the PVC")
 	flag.Parse()
 
 	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
@@ -51,33 +49,15 @@ func main() {
 		fmt.Printf("PVC name is required")
 		os.Exit(1)
 	}
-	// if namespacePtr == nil {
-	// 	fmt.Printf("namespace is required")
-	// 	os.Exit(1)
-	// }
-	// if targetPtr == nil {
-	// 	fmt.Printf("target (original or replicated) PV is required")
-	// 	os.Exit(1)
-	// }
 
 	rgName := *rgNamePtr
-	// namespace := *namespacePtr
-	// targetPV := *targetPtr
-
 	ctx := context.TODO()
-
 	err = swapAllPVC(ctx, clientset, rgName)
-	// err = swapPVC(ctx, clientset, pvcName, namespace, targetPV)
+
 }
 
-// https://stackoverflow.com/questions/51106923/labelselector-for-secrets-list-in-k8s
 func swapAllPVC(ctx context.Context, clientset *kubernetes.Clientset, rgName string) error {
 	fmt.Printf("calling getPVList from %s\n", rgName)
-
-	// 	LabelSelector: "replication.storage.dell.com/replicationGroupName: rg-f712dd5e-e9d2-4d36-850b-e79fc7e577b2",
-	// LabelSelector: {
-	// 	"replication.storage.dell.com/replicationGroupName": "rg-f712dd5e-e9d2-4d36-850b-e79fc7e577b2",
-	// },
 
 	labelSelector := metav1.LabelSelector{MatchLabels: map[string]string{"replication.storage.dell.com/replicationGroupName": rgName}}
 	listOptions := metav1.ListOptions{
@@ -85,7 +65,6 @@ func swapAllPVC(ctx context.Context, clientset *kubernetes.Clientset, rgName str
 	}
 
 	pvcs, err := clientset.CoreV1().PersistentVolumeClaims("").List(ctx, listOptions)
-	// pvcs, err = clientset.CoreV1().PersistentVolumeClaims("").List(ctx, metav1.ListOptions{})
 
 	if err != nil {
 		return fmt.Errorf("failed to list PVCs: %w", err)

--- a/scripts/pvcremap.go
+++ b/scripts/pvcremap.go
@@ -29,9 +29,9 @@ func main() {
 	} else {
 		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
 	}
-	pvcNamePtr := flag.String("v", "", "PVC to be rebound")
-	namespacePtr := flag.String("n", "", "namespace for the PVC to be rebound")
-	targetPtr := flag.String("t", "", "original or replicated indicating the desired target for the PVC")
+	rgNamePtr := flag.String("rg", "", "id for the RG")
+	// namespacePtr := flag.String("n", "", "namespace for the PVC to be rebound")
+	// targetPtr := flag.String("t", "", "original or replicated indicating the desired target for the PVC")
 	flag.Parse()
 
 	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
@@ -46,26 +46,31 @@ func main() {
 		os.Exit(1)
 	}
 
-	if pvcNamePtr == nil {
+	if rgNamePtr == nil {
 		fmt.Printf("PVC name is required")
 		os.Exit(1)
 	}
-	if namespacePtr == nil {
-		fmt.Printf("namespace is required")
-		os.Exit(1)
-	}
-	if targetPtr == nil {
-		fmt.Printf("target (original or replicated) PV is required")
-		os.Exit(1)
-	}
+	// if namespacePtr == nil {
+	// 	fmt.Printf("namespace is required")
+	// 	os.Exit(1)
+	// }
+	// if targetPtr == nil {
+	// 	fmt.Printf("target (original or replicated) PV is required")
+	// 	os.Exit(1)
+	// }
 
-	pvcName := *pvcNamePtr
-	namespace := *namespacePtr
-	targetPV := *targetPtr
+	rgName := *rgNamePtr
+	// namespace := *namespacePtr
+	// targetPV := *targetPtr
 
 	ctx := context.TODO()
+	
+	err = getPVList(ctx, clientset, rgName)
+	// err = swapPVC(ctx, clientset, pvcName, namespace, targetPV)
+}
 
-	err = swapPVC(ctx, clientset, pvcName, namespace, targetPV)
+func getPVList(ctx context.Context, clientset *kubernetes.Clientset, rgName string) error {
+	return nil
 }
 
 func swapPVC(ctx context.Context, clientset *kubernetes.Clientset, pvcName, namespace, targetPV string) error {

--- a/scripts/pvcremap.go
+++ b/scripts/pvcremap.go
@@ -66,7 +66,7 @@ func main() {
 
 	ctx := context.TODO()
 
-	err = getPVCList(ctx, clientset, rgName)
+	err =(ctx, clientset, rgName)
 	// err = swapPVC(ctx, clientset, pvcName, namespace, targetPV)
 }
 

--- a/scripts/pvcremap.go
+++ b/scripts/pvcremap.go
@@ -66,12 +66,12 @@ func main() {
 
 	ctx := context.TODO()
 
-	err =(ctx, clientset, rgName)
+	err = swapAllPVC(ctx, clientset, rgName)
 	// err = swapPVC(ctx, clientset, pvcName, namespace, targetPV)
 }
 
 // https://stackoverflow.com/questions/51106923/labelselector-for-secrets-list-in-k8s
-func getPVCList(ctx context.Context, clientset *kubernetes.Clientset, rgName string) error {
+func swapAllPVC(ctx context.Context, clientset *kubernetes.Clientset, rgName string) error {
 	fmt.Printf("calling getPVList from %s\n", rgName)
 
 	// 	LabelSelector: "replication.storage.dell.com/replicationGroupName: rg-f712dd5e-e9d2-4d36-850b-e79fc7e577b2",
@@ -93,7 +93,7 @@ func getPVCList(ctx context.Context, clientset *kubernetes.Clientset, rgName str
 	for _, pvc := range pvcs.Items {
 		pvcName := pvc.Name
 		namespace := pvc.Namespace
-		targetPV :=  pvc.Annotations[replicationPrefix+"remotePV"]
+		targetPV := pvc.Annotations[replicationPrefix+"remotePV"]
 		err = swapPVC(ctx, clientset, pvcName, namespace, targetPV)
 	}
 	return err

--- a/scripts/pvcremap.go
+++ b/scripts/pvcremap.go
@@ -70,6 +70,19 @@ func main() {
 }
 
 func getPVList(ctx context.Context, clientset *kubernetes.Clientset, rgName string) error {
+	fmt.Printf("calling getPVList\n")
+	pvcs, err := clientset.CoreV1().PersistentVolumeClaims("").List(ctx, metav1.ListOptions{
+	// 	LabelSelector: "replication.storage.dell.com/replicationGroupName: rg-f712dd5e-e9d2-4d36-850b-e79fc7e577b2",
+	})
+
+	if err != nil {
+		return fmt.Errorf("Failed to list PVCs: %w", err)
+	}
+	for _, pvc := range pvcs.Items {
+		fmt.Printf("reaching inside\n")
+		tmp:=pvc.Annotations["replication.storage.dell.com/replicationGroupName"]
+		fmt.Printf("%s\n",tmp)
+	}
 	return nil
 }
 


### PR DESCRIPTION
# Description
Update the pvcremap.go to remap all the pvcs within the specified replication group.
Testing with commandline: 
`go build pvcremap.go`
`./pvcremap -rg <rg-id>`

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|N/A |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Manual testing to see the 3 PVCs under one RG are successfully remapped
