### PR TITLE
Update README instruction for repctl static build on openSUSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Make sure that the kubernetes user has the desired RBAC permissions.
 
 #### Installation using repctl
 
-If you wish to install CSM Replication Controller with repctl on your OpenSUSE VM, when referring to this [section](https://dell.github.io/csm-docs/docs/deployment/helm/modules/installation/replication/install-repctl/), you need to install `glibc-devel-static` devel package before running `make build`.
+If you wish to install CSM Replication Controller with repctl on your OpenSUSE server, when referring to this [section](https://dell.github.io/csm-docs/docs/deployment/helm/modules/installation/replication/install-repctl/), you need to install `glibc-devel-static` devel package before running `make build`.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Make sure that the kubernetes user has the desired RBAC permissions.
 
 #### Installation using repctl
 
-If you wish to install CSM Replication Controller with repctl on your OpenSUSE server, when referring to this [section](https://dell.github.io/csm-docs/docs/deployment/helm/modules/installation/replication/install-repctl/), you need to install `glibc-devel-static` devel package before running `make build`.
+If you wish to install CSM Replication Controller with repctl on your openSUSE server, when referring to this [section](https://dell.github.io/csm-docs/docs/deployment/helm/modules/installation/replication/install-repctl/), you need to install `glibc-devel-static` devel package before running `make build`.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ You can install the CSM Replication Controller by running the command `make depl
 You can also run the `dell-replication-controller` process directly in your Kubernetes cluster by running the command `make run-controller`.
 Make sure that the kubernetes user has the desired RBAC permissions.
 
-#### Installation using repctl
+#### Platform Notes
 
 If you wish to install CSM Replication Controller with repctl on your openSUSE server, when referring to this [section](https://dell.github.io/csm-docs/docs/deployment/helm/modules/installation/replication/install-repctl/), you need to install `glibc-devel-static` devel package before running `make build`.
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ For building the RBAC rules for the controller, run `make controller-rbac`.
 
 ## Installation
 
-Please consult the [Installation Guide](https://dell.github.io/csm-docs/docs/replication/deployment/installation/) for instructions on installing the replication controller and sidecar.
+Please consult the [Installation Guide](https://dell.github.io/csm-docs/docs/deployment/helm/modules/installation/replication/installation/) for instructions on installing the replication controller and sidecar.
 
 To build and install your own images using the provided Makefile targets, below information may be useful:
 
@@ -141,6 +141,10 @@ You can install the CSM Replication Controller by running the command `make depl
 
 You can also run the `dell-replication-controller` process directly in your Kubernetes cluster by running the command `make run-controller`.
 Make sure that the kubernetes user has the desired RBAC permissions.
+
+#### Installation using repctl
+
+If you wish to install CSM Replication Controller with repctl on your OpenSUSE VM, when referring to this [section](https://dell.github.io/csm-docs/docs/deployment/helm/modules/installation/replication/install-repctl/), you need to install `glibc-devel-static` devel package before running `make build`.
 
 ## Testing
 


### PR DESCRIPTION
# Description
Root cause: `make build` under repctl fails due to missing the `glibc-devel-static` devel package.
Fix: Update a README section to address the issue. Additionally, the broken link in the Installation section is fixed.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1330 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
- [x] I have newly built the binary. The build succeeded with no error.
- [x] I tested several repctl commands.

# Screenshot:
![image](https://github.com/dell/csm-replication/assets/171162480/bb0846e0-026c-470e-84a5-9a5de9572c24)
