### PR TITLE
[csm-1385] Revert change to build static repctl.

### DIFF
--- a/repctl/Makefile
+++ b/repctl/Makefile
@@ -3,6 +3,12 @@ all: build
 build:
 	cp -f ../scripts/gen_kubeconfig.sh ./pkg/cmd/scripts/gen_kubeconfig.sh
 	cp -f ../scripts/config-placeholder ./pkg/cmd/scripts/config-placeholder
+	go build ./cmd/repctl
+
+# Build static binary, the build can be platform dependent so may need tweaking.
+build-static:
+	cp -f ../scripts/gen_kubeconfig.sh ./pkg/cmd/scripts/gen_kubeconfig.sh
+	cp -f ../scripts/config-placeholder ./pkg/cmd/scripts/config-placeholder
 	CGO_ENABLED=1 CGO_LDFLAGS="-static" go build ./cmd/repctl
 
 test:
@@ -16,5 +22,11 @@ tools:
 
 mocks:
 	mockery --all --disable-version-string
+
+clean:
+	rm -f ./pkg/cmd/scripts/gen_kubeconfig.sh
+	rm -f ./pkg/cmd/scripts/config-placeholder
+	go clean -cache
+	rm -f repctl
 
 .PHONY: mocks


### PR DESCRIPTION
# Description
Revert [137](https://github.com/dell/csm-replication/pull/137) and add a separate target, build-static for building a static binary. 

# GitHub Issues

| GitHub Issue # |
| -------------- |
| [1385](https://github.com/dell/csm/issues/1385)|

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X] Unit tests. 
- [X] Manual execution of repctl binary.

No additional tests added as no functionality was changed. 
