### PR TITLE
Adding missing test dirs to unit-test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,9 +182,23 @@ unit-test-csi-replicator:
 unit-test-replication-controller:
 	go test ./controllers/replication-controller/ -v -race -coverpkg=./controllers/replication-controller/ -coverprofile cover.out
 
-# Execute unit tests for all the controllers and generate coverage report
-unit-test:
-	( cd controllers; go clean -cache; go test -race -v -cover ./... -coverprofile cover.out )
+# Execute all unit tests and generate coverage report
+unit-test: clean test-cmd test-pkg test-controllers
+
+clean:
+	go clean -cache
+
+# Execute unit tests in ./cmd and generate coverage report
+test-cmd:
+	( cd cmd; go test -race -cover ./... -coverprofile cmd-cover.out )
+
+# Execute unit tests in ./pkg and generate coverage report
+test-pkg:
+	( cd pkg; go test -race -cover ./... -coverprofile pkg-cover.out )
+
+# Execute unit tests in ./controllers and generate coverage report
+test-controllers:
+	( cd controllers; go test -race -cover ./... -coverprofile ctrl-cover.out )
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.4.3


### PR DESCRIPTION
# Description
GitHub actions was only running unit test for the controller directory and repctl.
This commit creates new makefile targets for the directories with relevant code for which unit tests should be run.

> Note: the `make test` target would have been used, but it also attempts to run the golang tests for e2e in the ./test directory.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1559 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Used the Makefile target `make unit-test` to execute the unit tests.
![image](https://github.com/user-attachments/assets/067700c9-3fd8-4237-bcc8-9e270b5d3af9)
