### PR TITLE
Add preflight required labels.

### DIFF
--- a/Dockerfiles/Dockerfile
+++ b/Dockerfiles/Dockerfile
@@ -32,6 +32,11 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o dell-csi
 
 # Base image
 FROM $BASEIMAGE AS container-base
+LABEL vendor="Dell Technologies" \
+      maintainer="Dell Technologies" \
+      release="1.13.0" \
+      version="1.11.0" \
+      license="Apache-2.0"
 
 # Controller
 FROM container-base AS controller
@@ -39,6 +44,9 @@ COPY licenses licenses/
 WORKDIR /
 COPY --from=builder /workspace/dell-csi-replicator/dell-replication-controller ./
 ENTRYPOINT ["/dell-replication-controller"]
+LABEL name="dell-replication-controller" \
+    description="CSI Replication controller" \
+    summary="Controller which replicates the resources across (or within) Kubernetes clusters"
 
 # Sidecar
 FROM container-base AS sidecar
@@ -46,6 +54,9 @@ COPY licenses licenses/
 WORKDIR /
 COPY --from=builder /workspace/dell-csi-replicator/dell-csi-replicator ./
 ENTRYPOINT ["/dell-csi-replicator"]
+LABEL name="dell-csi-replicator" \
+    description="CSI Replicator sidecar" \
+    summary="Sidecar used for managing the replication processes"
 
 # Sidecar migrator
 FROM container-base AS migrator
@@ -53,6 +64,9 @@ COPY licenses licenses/
 WORKDIR /
 COPY --from=builder /workspace/dell-csi-replicator/dell-csi-migrator ./
 ENTRYPOINT ["/dell-csi-migrator"]
+LABEL name="dell-csi-migrator" \
+    description="CSI Migrator sidecar" \
+    summary="Sidecar used for managing the replication processes"
 
 # Sidecar node-rescanner
 FROM container-base AS node-rescanner
@@ -60,3 +74,6 @@ COPY licenses licenses/
 WORKDIR /
 COPY --from=builder /workspace/dell-csi-replicator/dell-csi-node-rescanner ./
 ENTRYPOINT ["/dell-csi-node-rescanner"]
+LABEL name="dell-csi-node-rescanner" \
+    description="CSI Node Rescanner sidecar" \
+    summary="Sidecar used for managing the replication processes"


### PR DESCRIPTION
# Description
Added the required labels to the image container so that it can pass preflight checks.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1667 |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Built image. Docker inspect shows:

{
  "architecture": "x86_64",
  "build-date": "2024-08-27T19:24:54",
  "com.redhat.component": "ubi9-micro-container",
  "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
  "description": "CSI Replication controller",
  "distribution-scope": "public",
  "io.buildah.version": "1.29.4",
  "io.k8s.description": "Very small image which doesn't install the package manager.",
  "io.k8s.display-name": "Ubi9-micro",
  "io.openshift.expose-services": "",
  "license": "Apache-2.0",
  "maintainer": "Dell Technologies",
  "name": "dell-replication-controller",
  "release": "1.13.0",
  "summary": "Controller which replicates the resources across (or within) Kubernetes clusters",
  "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi9/ubi-micro/images/9.4-15",
  "vcs-ref": "cd5996c9b8b99b546584696465f8f39ec682078c",
  "vcs-type": "git",
  "vendor": "Dell Technologies",
  "version": "1.11.0"
}

{
  "architecture": "x86_64",
  "build-date": "2024-08-27T19:24:54",
  "com.redhat.component": "ubi9-micro-container",
  "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
  "description": "CSI Node Rescanner sidecar",
  "distribution-scope": "public",
  "io.buildah.version": "1.29.4",
  "io.k8s.description": "Very small image which doesn't install the package manager.",
  "io.k8s.display-name": "Ubi9-micro",
  "io.openshift.expose-services": "",
  "license": "Apache-2.0",
  "maintainer": "Dell Technologies",
  "name": "dell-csi-node-rescanner",
  "release": "1.13.0",
  "summary": "Sidecar used for managing the replication processes",
  "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi9/ubi-micro/images/9.4-15",
  "vcs-ref": "cd5996c9b8b99b546584696465f8f39ec682078c",
  "vcs-type": "git",
  "vendor": "Dell Technologies",
  "version": "1.11.0"
}

{
  "architecture": "x86_64",
  "build-date": "2024-08-27T19:24:54",
  "com.redhat.component": "ubi9-micro-container",
  "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
  "description": "CSI Migrator sidecar",
  "distribution-scope": "public",
  "io.buildah.version": "1.29.4",
  "io.k8s.description": "Very small image which doesn't install the package manager.",
  "io.k8s.display-name": "Ubi9-micro",
  "io.openshift.expose-services": "",
  "license": "Apache-2.0",
  "maintainer": "Dell Technologies",
  "name": "dell-csi-migrator",
  "release": "1.13.0",
  "summary": "Sidecar used for managing the replication processes",
  "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi9/ubi-micro/images/9.4-15",
  "vcs-ref": "cd5996c9b8b99b546584696465f8f39ec682078c",
  "vcs-type": "git",
  "vendor": "Dell Technologies",
  "version": "1.11.0"
}

{
  "architecture": "x86_64",
  "build-date": "2024-08-27T19:24:54",
  "com.redhat.component": "ubi9-micro-container",
  "com.redhat.license_terms": "https://www.redhat.com/en/about/red-hat-end-user-license-agreements#UBI",
  "description": "CSI Replicator sidecar",
  "distribution-scope": "public",
  "io.buildah.version": "1.29.4",
  "io.k8s.description": "Very small image which doesn't install the package manager.",
  "io.k8s.display-name": "Ubi9-micro",
  "io.openshift.expose-services": "",
  "license": "Apache-2.0",
  "maintainer": "Dell Technologies",
  "name": "dell-csi-replicator",
  "release": "1.13.0",
  "summary": "Sidecar used for managing the replication processes",
  "url": "https://access.redhat.com/containers/#/registry.access.redhat.com/ubi9/ubi-micro/images/9.4-15",
  "vcs-ref": "cd5996c9b8b99b546584696465f8f39ec682078c",
  "vcs-type": "git",
  "vendor": "Dell Technologies",
  "version": "1.11.0"
}
