### PR TITLE
PVC remap feature for csm-replication on stretched cluster

### DIFF
--- a/cmd/replication-controller/main_test.go
+++ b/cmd/replication-controller/main_test.go
@@ -943,7 +943,7 @@ func TestCreateReplicationGroupReconciler(t *testing.T) {
 					}
 				}()
 			}
-			createReplicationGroupReconciler(tt.manager, tt.controllerMgr, tt.domain, tt.workerThreads, tt.expRateLimiter, tt.setupLog)
+			createReplicationGroupReconciler(tt.manager, tt.controllerMgr, tt.domain, tt.workerThreads, tt.expRateLimiter, false, tt.setupLog)
 			if tt.name == "Manager is not nil" {
 				if exitCode != 0 {
 					t.Errorf("Expected exit code 0, but got %d", exitCode)

--- a/controllers/replication-controller/dellcsireplicationgroup_controller_test.go
+++ b/controllers/replication-controller/dellcsireplicationgroup_controller_test.go
@@ -19,12 +19,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	repv1 "github.com/dell/csm-replication/api/v1"
 	"github.com/dell/csm-replication/controllers"
-
 	csireplicator "github.com/dell/csm-replication/controllers/csi-replicator"
 	constants "github.com/dell/csm-replication/pkg/common"
 	"github.com/dell/csm-replication/pkg/connection"
@@ -33,6 +33,7 @@ import (
 	"github.com/go-logr/logr"
 	s1 "github.com/kubernetes-csi/external-snapshotter/client/v4/apis/volumesnapshot/v1"
 	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -51,6 +52,7 @@ type RGControllerTestSuite struct {
 	driver     utils.Driver
 	config     connection.MultiClusterClient
 	reconciler *ReplicationGroupReconciler
+	mockUtils  *utils.MockUtils
 }
 
 func TestRGControllerTestSuite(t *testing.T) {
@@ -575,7 +577,7 @@ func (suite *RGControllerTestSuite) TestProcessLastActionResult() {
 	suite.NoError(err)
 
 	// Process the last action. Should update the RG, updating the actionProcessedTime annotation
-	err = suite.reconciler.processLastActionResult(context.Background(), rg, remoteClient, suite.reconciler.Log)
+	err = suite.reconciler.processLastActionResult(context.Background(), rg, rg, remoteClient, suite.reconciler.Log)
 	suite.NoError(err, "processLastActionResult should not fail")
 
 	updatedRG := new(repv1.DellCSIReplicationGroup)
@@ -614,7 +616,7 @@ func (suite *RGControllerTestSuite) TestProcessLastActionResult_AlreadyProcessed
 	suite.NoError(err)
 
 	// Process the last action. Should update the RG, updating the actionProcessedTime annotation
-	err = suite.reconciler.processLastActionResult(context.Background(), rg, remoteClient, suite.reconciler.Log)
+	err = suite.reconciler.processLastActionResult(context.Background(), rg, rg, remoteClient, suite.reconciler.Log)
 	suite.NoError(err, "processLastActionResult should do nothing")
 	// Ideally, we'd check the log output here to confirm it logged "Last action has already been processed", but
 	// it appears there is no method to get the log output.
@@ -648,7 +650,7 @@ func (suite *RGControllerTestSuite) TestProcessLastActionResult_NoActionProcesse
 	suite.NoError(err)
 
 	// Process the last action. Should update the RG, updating the actionProcessedTime annotation
-	err = suite.reconciler.processLastActionResult(context.Background(), rg, remoteClient, suite.reconciler.Log)
+	err = suite.reconciler.processLastActionResult(context.Background(), rg, rg, remoteClient, suite.reconciler.Log)
 	suite.NoError(err, "processLastActionResult should do nothing")
 	// Ideally, we'd check the log output here to confirm it logged "Action Processed does not exist", but
 	// it appears there is no method to get the log output.
@@ -829,7 +831,7 @@ func TestReplicationGroupReconciler_processLastActionResult(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &ReplicationGroupReconciler{}
-			if err := r.processLastActionResult(tt.args.ctx, tt.args.group, tt.args.remoteClient, tt.args.log); (err != nil) != tt.wantErr {
+			if err := r.processLastActionResult(tt.args.ctx, tt.args.group, tt.args.group, tt.args.remoteClient, tt.args.log); (err != nil) != tt.wantErr {
 				t.Errorf("ReplicationGroupReconciler.processLastActionResult() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
@@ -1011,6 +1013,711 @@ func TestReplicationGroupReconciler_processSnapshotEvent(t *testing.T) {
 			r := &ReplicationGroupReconciler{}
 			if err := r.processSnapshotEvent(context.Background(), tt.group, tt.remoteClient, tt.log); (err != nil) != tt.wantErr {
 				t.Errorf("ReplicationGroupReconciler.processLastActionResult() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// getSingleClusterPVSetup creates replication group, remote replication group,
+// a pair of PVs, and a PVC for single cluster.
+func (suite *RGControllerTestSuite) getSingleClusterPVSetup() (*repv1.DellCSIReplicationGroup, *repv1.DellCSIReplicationGroup, *corev1.PersistentVolume, *corev1.PersistentVolume, *corev1.PersistentVolumeClaim) {
+	// scenario: RG without sync complete
+	newConfig := mocks.NewFakeConfigForSingleCluster(suite.client,
+		suite.driver.SourceClusterID, suite.driver.RemoteClusterID)
+	suite.config = newConfig
+	suite.reconciler.Config = newConfig
+	sc1 := utils.GetReplicationEnabledSC(suite.driver.DriverName, "sc-1",
+		"sc-2", utils.Self)
+	// create sc-1 and corresponding RG
+	rg1 := suite.getRGWithoutSyncComplete(suite.driver.RGName, true, true)
+	labels := make(map[string]string)
+	labels[controllers.DriverName] = suite.driver.DriverName
+	rg1.Labels = labels
+	suite.createSCAndRG(sc1, rg1)
+	// create sc-2
+	sc2 := utils.GetReplicationEnabledSC(suite.driver.DriverName, "sc-2",
+		"sc-1", utils.Self)
+	err := suite.client.Create(context.Background(), sc2)
+	suite.NoError(err)
+
+	rg := new(repv1.DellCSIReplicationGroup)
+	req := suite.getTypicalRequest()
+
+	suite.NotContains(controllers.RemoteReplicationGroup, rg.Annotations,
+		"Remote RG annotation doesn't exist")
+	suite.NotContains(controllers.RGSyncComplete, rg.Annotations,
+		"RG Sync annotation doesn't exist")
+
+	resp, err := suite.reconciler.Reconcile(context.Background(), req)
+	suite.NoError(err)
+	suite.Equal(false, resp.Requeue)
+	err = suite.client.Get(context.Background(), req.NamespacedName, rg)
+	suite.NoError(err)
+	suite.Equal("yes", rg.Annotations[controllers.RGSyncComplete],
+		"RG Sync annotation applied")
+	replicatedRGName := fmt.Sprintf("%s-%s", replicated, rg.Name)
+	suite.Equal(replicatedRGName, rg.Annotations[controllers.RemoteReplicationGroup],
+		"Remote RG annotation applied")
+
+	// Check if remote RG got created
+	rClient, err := suite.config.GetConnection("self")
+	suite.NoError(err)
+	replicatedRG, err := rClient.GetReplicationGroup(context.Background(), replicatedRGName)
+	suite.NoError(err)
+
+	// rgName, replicatedRGName
+	rgName := rg.Name
+	ctx := context.Background()
+
+	// create local and remote PV
+	localAnnotations := make(map[string]string)
+	localAnnotations[controllers.RGSyncComplete] = "yes"
+	localAnnotations[controllers.ReplicationGroup] = rgName
+	localAnnotations[controllers.RemoteReplicationGroup] = replicatedRGName
+	localAnnotations[controllers.RemoteClusterID] = "self"
+	localAnnotations[controllers.ContextPrefix] = "csi-fake"
+	localAnnotations[controllers.RemotePV] = "remote-pv"
+	localAnnotations[controllers.RemotePVRetentionPolicy] = "delete"
+	localAnnotations[controllers.RemoteVolumeAnnotation] = `{"capacity_bytes":3000023,"volume_id":"pvc-d559bbfa-6612-4b57-a542-5ca64c9625fe","volume_context":{"RdfGroup":"2","RdfMode":"ASYNC","RemoteRDFGroup":"2","RemoteSYMID":"000000000002","RemoteServiceLevel":"Bronze","SRP":"SRP_1","SYMID":"000000000001","ServiceLevel":"Bronze","replication.storage.dell.com/remotePVRetentionPolicy":"delete","storage.dell.com/isReplicationEnabled":"true","storage.dell.com/remoteClusterID":"self","storage.dell.com/remoteStorageClassName":"sc-2"}}`
+
+	localLabels := make(map[string]string)
+	localLabels[controllers.DriverName] = suite.driver.DriverName
+	localLabels[controllers.ReplicationGroup] = rgName
+	localLabels[controllers.RemoteClusterID] = "self"
+
+	remoteAnnotations := make(map[string]string)
+	remoteAnnotations[controllers.RGSyncComplete] = "yes"
+	remoteAnnotations[controllers.ReplicationGroup] = replicatedRGName
+	remoteAnnotations[controllers.RemoteReplicationGroup] = rgName
+	remoteAnnotations[controllers.RemoteClusterID] = "self"
+	remoteAnnotations[controllers.ContextPrefix] = "csi-fake"
+	remoteAnnotations[controllers.RemotePV] = "local-pv"
+	remoteAnnotations[controllers.RemotePVRetentionPolicy] = "delete"
+	remoteAnnotations[controllers.RemoteVolumeAnnotation] = `{"capacity_bytes":3000023,"volume_id":"pvc-d559bbfa-6612-4b57-a542-5ca64c9625fe","volume_context":{"RdfGroup":"2","RdfMode":"ASYNC","RemoteRDFGroup":"2","RemoteSYMID":"000000000002","RemoteServiceLevel":"Bronze","SRP":"SRP_1","SYMID":"000000000001","ServiceLevel":"Bronze","replication.storage.dell.com/remotePVRetentionPolicy":"delete","storage.dell.com/isReplicationEnabled":"true","storage.dell.com/remoteClusterID":"self","storage.dell.com/remoteStorageClassName":"sc-1"}}`
+
+	remoteLabels := make(map[string]string)
+	remoteLabels[controllers.DriverName] = suite.driver.DriverName
+	remoteLabels[controllers.ReplicationGroup] = replicatedRGName
+	remoteLabels[controllers.RemoteClusterID] = "self"
+
+	localPV := utils.GetPVObj("local-pv", "vol-handle", suite.driver.DriverName, "sc-1", nil)
+	localPV.Labels = localLabels
+	localPV.Annotations = localAnnotations
+	localPV.Spec.PersistentVolumeReclaimPolicy = controllers.RemoteRetentionValueDelete
+
+	localClaimRef := &corev1.ObjectReference{
+		Kind:            "PersistentVolumeClaim",
+		Namespace:       "fake-ns",
+		Name:            "fake-pvc",
+		UID:             "18802349-2128-43a8-8169-bbb1ca8a4c67",
+		APIVersion:      "v1",
+		ResourceVersion: "32776691",
+	}
+	localPV.Spec.ClaimRef = localClaimRef
+	err = suite.client.Create(ctx, localPV)
+	suite.NoError(err)
+
+	remotePV := utils.GetPVObj("remote-pv", "vol-handle", suite.driver.DriverName, "sc-2", nil)
+	localPV.Labels = remoteLabels
+	remotePV.Annotations = remoteAnnotations
+	remotePV.Spec.PersistentVolumeReclaimPolicy = controllers.RemoteRetentionValueDelete
+	err = suite.client.Create(ctx, remotePV)
+	suite.NoError(err)
+
+	_, err = suite.reconciler.Reconcile(context.Background(), req)
+	suite.NoError(err)
+
+	// create pvc
+	pvcAnnotations := make(map[string]string)
+	pvcAnnotations[controllers.RGSyncComplete] = "yes"
+	pvcAnnotations[controllers.ReplicationGroup] = rgName
+	pvcAnnotations[controllers.RemoteReplicationGroup] = replicatedRGName
+	pvcAnnotations[controllers.RemoteClusterID] = "self"
+	pvcAnnotations[controllers.RemoteStorageClassAnnotation] = "sc-2"
+	pvcAnnotations[controllers.ContextPrefix] = "csi-fake"
+	pvcAnnotations[controllers.RemotePV] = "remote-pv"
+	pvcAnnotations[controllers.RemoteVolumeAnnotation] = `{"capacity_bytes":3000023,"volume_id":"pvc-d559bbfa-6612-4b57-a542-5ca64c9625fe","volume_context":{"RdfGroup":"2","RdfMode":"ASYNC","RemoteRDFGroup":"2","RemoteSYMID":"000000000002","RemoteServiceLevel":"Bronze","SRP":"SRP_1","SYMID":"000000000001","ServiceLevel":"Bronze","replication.storage.dell.com/remotePVRetentionPolicy":"delete","storage.dell.com/isReplicationEnabled":"true","storage.dell.com/remoteClusterID":"self","storage.dell.com/remoteStorageClassName":"sc-2"}}`
+
+	pvcLabels := make(map[string]string)
+	pvcLabels[controllers.DriverName] = suite.driver.DriverName
+	pvcLabels[controllers.ReplicationGroup] = rgName
+	pvcLabels[controllers.RemoteClusterID] = "self"
+
+	pvcObj := utils.GetPVCObj("fake-pvc", "fake-ns", "sc-1")
+	pvcObj.Status.Phase = corev1.ClaimBound
+	pvcObj.Spec.VolumeName = "local-pv"
+	pvcObj.Annotations = pvcAnnotations
+	pvcObj.Labels = pvcLabels
+
+	err = suite.client.Create(ctx, pvcObj)
+	suite.NoError(err)
+	suite.NotNil(suite.T(), pvcObj)
+
+	_, err = suite.reconciler.Reconcile(context.Background(), req)
+	suite.NoError(err)
+
+	return rg, replicatedRG, localPV, remotePV, pvcObj
+}
+
+func (suite *RGControllerTestSuite) TestPVCRemapPlanned() {
+	rg, replicatedRG, _, _, _ := suite.getSingleClusterPVSetup()
+	replicatedRGName := replicatedRG.Name
+
+	// Invoke failover action
+	time := metav1.Now()
+	lastAction := repv1.LastAction{
+		Time:      &time,
+		Condition: "Action FAILOVER_REMOTE succeeded",
+	}
+	rg.Status = repv1.DellCSIReplicationGroupStatus{
+		LastAction: lastAction,
+		Conditions: []repv1.LastAction{lastAction},
+	}
+	rg.Annotations[controllers.ActionProcessedTime] = time.String()
+
+	err := suite.client.Update(context.Background(), rg)
+	suite.NoError(err)
+
+	// Reconcile to trigger processFailoverAction
+	req := suite.getTypicalRequest()
+	resp, err := suite.reconciler.Reconcile(context.Background(), req)
+	suite.NoError(err)
+	suite.Equal(false, resp.Requeue)
+
+	// Verify PVC swap occurred
+	var swappedPVC corev1.PersistentVolumeClaim
+	err = suite.client.Get(context.Background(), types.NamespacedName{Name: "fake-pvc", Namespace: "fake-ns"}, &swappedPVC)
+	suite.NoError(err)
+
+	suite.Equal("remote-pv", swappedPVC.Spec.VolumeName, "PVC should now be bound to the remote PV")
+	suite.Equal("sc-2", *swappedPVC.Spec.StorageClassName, "PVC should now use the remote storage class")
+	suite.Equal("local-pv", swappedPVC.Annotations[controllers.RemotePV], "Remote PV annotation should be updated")
+	suite.Equal(replicatedRGName, swappedPVC.Annotations[controllers.ReplicationGroup], "Replication group annotation should be updated")
+
+	// Verify remote PV's claim reference
+	var updatedRemotePV corev1.PersistentVolume
+	err = suite.client.Get(context.Background(), types.NamespacedName{Name: "remote-pv"}, &updatedRemotePV)
+	suite.NoError(err)
+	suite.Equal(controllers.RemoteRetentionValueDelete, string(updatedRemotePV.Spec.PersistentVolumeReclaimPolicy), "Remote PV reclaim policy should be 'Delete' after swapAllPVC")
+	suite.Equal("fake-pvc", updatedRemotePV.Spec.ClaimRef.Name, "Remote PV should now be claimed by the PVC")
+	suite.Equal("fake-ns", updatedRemotePV.Spec.ClaimRef.Namespace)
+
+	// Verify local PV's claim reference is removed
+	var updatedLocalPV corev1.PersistentVolume
+	err = suite.client.Get(context.Background(), types.NamespacedName{Name: "local-pv"}, &updatedLocalPV)
+	suite.NoError(err)
+	suite.Nil(updatedLocalPV.Spec.ClaimRef, "Local PV's claim reference should be removed")
+	suite.Equal(controllers.RemoteRetentionValueDelete, string(updatedLocalPV.Spec.PersistentVolumeReclaimPolicy), "Local PV reclaim policy should be 'Delete' after swapAllPVC")
+}
+
+func (suite *RGControllerTestSuite) TestPVCRemapUnplanned() {
+	_, replicatedRG, _, _, _ := suite.getSingleClusterPVSetup()
+	replicatedRGName := replicatedRG.Name
+
+	// Invoke failover action
+	time := metav1.Now()
+	lastAction := repv1.LastAction{
+		Time:      &time,
+		Condition: "Action UNPLANNED_FAILOVER_LOCAL succeeded",
+	}
+	replicatedRG.Status = repv1.DellCSIReplicationGroupStatus{
+		LastAction: lastAction,
+		Conditions: []repv1.LastAction{lastAction},
+	}
+	replicatedRG.Annotations[controllers.ActionProcessedTime] = time.String()
+	replicatedRG.Annotations[controllers.RGSyncComplete] = "yes"
+	replicatedRG.Finalizers = append(replicatedRG.Finalizers, controllers.RGFinalizer)
+	err := suite.client.Update(context.Background(), replicatedRG)
+	suite.NoError(err)
+
+	rgReq := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name: replicatedRGName,
+		},
+	}
+	resp, err := suite.reconciler.Reconcile(context.Background(), rgReq)
+	suite.NoError(err)
+	suite.Equal(false, resp.Requeue)
+
+	// Verify PVC swap occurred
+	var swappedPVC corev1.PersistentVolumeClaim
+	err = suite.client.Get(context.Background(), types.NamespacedName{Name: "fake-pvc", Namespace: "fake-ns"}, &swappedPVC)
+	suite.NoError(err)
+
+	suite.Equal("remote-pv", swappedPVC.Spec.VolumeName, "PVC should now be bound to the remote PV")
+	suite.Equal("sc-2", *swappedPVC.Spec.StorageClassName, "PVC should now use the remote storage class")
+	suite.Equal("local-pv", swappedPVC.Annotations[controllers.RemotePV], "Remote PV annotation should be updated")
+	suite.Equal(replicatedRGName, swappedPVC.Annotations[controllers.ReplicationGroup], "Replication group annotation should be updated")
+
+	// Verify remote PV's claim reference
+	var updatedRemotePV corev1.PersistentVolume
+	err = suite.client.Get(context.Background(), types.NamespacedName{Name: "remote-pv"}, &updatedRemotePV)
+	suite.NoError(err)
+	suite.Equal(controllers.RemoteRetentionValueDelete, string(updatedRemotePV.Spec.PersistentVolumeReclaimPolicy), "Remote PV reclaim policy should be 'Delete' after swapAllPVC")
+	suite.Equal("fake-pvc", updatedRemotePV.Spec.ClaimRef.Name, "Remote PV should now be claimed by the PVC")
+	suite.Equal("fake-ns", updatedRemotePV.Spec.ClaimRef.Namespace)
+
+	// Verify local PV's claim reference is removed
+	var updatedLocalPV corev1.PersistentVolume
+	err = suite.client.Get(context.Background(), types.NamespacedName{Name: "local-pv"}, &updatedLocalPV)
+	suite.NoError(err)
+	suite.Nil(updatedLocalPV.Spec.ClaimRef, "Local PV's claim reference should be removed")
+	suite.Equal(controllers.RemoteRetentionValueDelete, string(updatedLocalPV.Spec.PersistentVolumeReclaimPolicy), "Local PV reclaim policy should be 'Delete' after swapAllPVC")
+}
+
+func (suite *RGControllerTestSuite) TestPVCRemapDisabled() {
+	rg, _, _, _, _ := suite.getSingleClusterPVSetup()
+	rgName := rg.Name
+	suite.reconciler.DisablePVCRemap = true // Disable PVC remapping
+
+	// Invoke failover action
+	time := metav1.Now()
+	lastAction := repv1.LastAction{
+		Time:      &time,
+		Condition: "Action FAILOVER_REMOTE succeeded",
+	}
+	rg.Status = repv1.DellCSIReplicationGroupStatus{
+		LastAction: lastAction,
+		Conditions: []repv1.LastAction{lastAction},
+	}
+	rg.Annotations[controllers.ActionProcessedTime] = time.String()
+
+	err := suite.client.Update(context.Background(), rg)
+	suite.NoError(err)
+
+	// Reconcile to trigger processFailoverAction
+	req := suite.getTypicalRequest()
+	resp, err := suite.reconciler.Reconcile(context.Background(), req)
+	suite.NoError(err)
+	suite.Equal(false, resp.Requeue)
+
+	// Verify that PVC swap did not occur
+	var unchangedPVC corev1.PersistentVolumeClaim
+	err = suite.client.Get(context.Background(), types.NamespacedName{Name: "fake-pvc", Namespace: "fake-ns"}, &unchangedPVC)
+	suite.NoError(err)
+
+	suite.Equal("local-pv", unchangedPVC.Spec.VolumeName, "PVC should still be bound to the local PV")
+	suite.Equal("sc-1", *unchangedPVC.Spec.StorageClassName, "PVC should still use the local storage class")
+	suite.Equal("remote-pv", unchangedPVC.Annotations[controllers.RemotePV], "Remote PV annotation should remain unchanged")
+	suite.Equal(rgName, unchangedPVC.Annotations[controllers.ReplicationGroup], "Replication group annotation should remain unchanged")
+
+	// Verify local PV's claim reference is unchanged
+	var unchangedLocalPV corev1.PersistentVolume
+	err = suite.client.Get(context.Background(), types.NamespacedName{Name: "local-pv"}, &unchangedLocalPV)
+	suite.NoError(err)
+	suite.NotNil(unchangedLocalPV.Spec.ClaimRef, "Local PV's claim reference should remain")
+	suite.Equal("fake-pvc", unchangedLocalPV.Spec.ClaimRef.Name, "Local PV should still be claimed by the original PVC")
+	suite.Equal("fake-ns", unchangedLocalPV.Spec.ClaimRef.Namespace)
+
+	// Verify remote PV's claim reference is unchanged
+	var unchangedRemotePV corev1.PersistentVolume
+	err = suite.client.Get(context.Background(), types.NamespacedName{Name: "remote-pv"}, &unchangedRemotePV)
+	suite.NoError(err)
+	suite.Nil(unchangedRemotePV.Spec.ClaimRef, "Remote PV's claim reference should remain nil")
+}
+
+func (suite *RGControllerTestSuite) TestPVCRemapWithMismatchedRemotePV() {
+	rg, _, localPV, remotePV, pvcObj := suite.getSingleClusterPVSetup()
+	rgName := rg.Name
+	ctx := context.Background()
+	// Modify the remotePV annotation to create a mismatch
+	pvcObj.Annotations[controllers.RemotePV] = "mismatched-pv"
+	err := suite.client.Update(ctx, pvcObj)
+	suite.NoError(err)
+
+	req := suite.getTypicalRequest()
+	_, err = suite.reconciler.Reconcile(context.Background(), req)
+	suite.NoError(err)
+
+	// Invoke failover action
+	time := metav1.Now()
+	lastAction := repv1.LastAction{
+		Time:      &time,
+		Condition: "Action FAILOVER_REMOTE succeeded",
+	}
+	rg.Status = repv1.DellCSIReplicationGroupStatus{
+		LastAction: lastAction,
+		Conditions: []repv1.LastAction{lastAction},
+	}
+	rg.Annotations[controllers.ActionProcessedTime] = time.String()
+
+	err = suite.client.Update(context.Background(), rg)
+	suite.NoError(err)
+
+	// Reconcile to trigger processFailoverAction
+	resp, err := suite.reconciler.Reconcile(context.Background(), req)
+	suite.NoError(err)
+	suite.Equal(false, resp.Requeue)
+
+	// Verify that the PVC swap did not occur due to mismatched target
+	var unchangedPVC corev1.PersistentVolumeClaim
+	err = suite.client.Get(context.Background(), types.NamespacedName{Name: pvcObj.Name, Namespace: pvcObj.Namespace}, &unchangedPVC)
+	suite.NoError(err)
+
+	suite.Equal(localPV.Name, unchangedPVC.Spec.VolumeName, "PVC should still be bound to the local PV")
+	suite.Equal("sc-1", *unchangedPVC.Spec.StorageClassName, "PVC should still use the local storage class")
+	suite.Equal("mismatched-pv", unchangedPVC.Annotations[controllers.RemotePV], "Remote PV annotation should remain unchanged")
+	suite.Equal(rgName, unchangedPVC.Annotations[controllers.ReplicationGroup], "Replication group annotation should remain unchanged")
+
+	// Verify local PV's claim reference is unchanged
+	var unchangedLocalPV corev1.PersistentVolume
+	err = suite.client.Get(context.Background(), types.NamespacedName{Name: localPV.Name}, &unchangedLocalPV)
+	suite.NoError(err)
+	suite.NotNil(unchangedLocalPV.Spec.ClaimRef, "Local PV's claim reference should remain")
+	suite.Equal(pvcObj.Name, unchangedLocalPV.Spec.ClaimRef.Name, "Local PV should still be claimed by the original PVC")
+	suite.Equal(pvcObj.Namespace, unchangedLocalPV.Spec.ClaimRef.Namespace)
+
+	// Verify remote PV's claim reference is unchanged
+	var unchangedRemotePV corev1.PersistentVolume
+	err = suite.client.Get(context.Background(), types.NamespacedName{Name: remotePV.Name}, &unchangedRemotePV)
+	suite.NoError(err)
+	suite.Nil(unchangedRemotePV.Spec.ClaimRef, "Remote PV's claim reference should remain nil")
+}
+
+func TestUpdatePVClaimRef(t *testing.T) {
+	originalGetPersistentVolume := getPersistentVolume
+	originalUpdatePersistentVolume := updatePersistentVolume
+
+	after := func() {
+		getPersistentVolume = originalGetPersistentVolume
+		updatePersistentVolume = originalUpdatePersistentVolume
+	}
+
+	tests := []struct {
+		name               string
+		pv                 *v1.PersistentVolume
+		client             connection.RemoteClusterClient
+		pvName             string
+		pvcNamespace       string
+		pvcResourceVersion string
+		pvcName            string
+		pvcUID             types.UID
+		log                logr.Logger
+		setup              func()
+		expectedErr        bool
+	}{
+		{
+			name:   "Error in getting persisitent volume",
+			pvName: "",
+			pv: &corev1.PersistentVolume{
+				Spec: corev1.PersistentVolumeSpec{
+					ClaimRef: &corev1.ObjectReference{
+						Kind:            "PersistentVolumeClaim",
+						Namespace:       "fake-ns",
+						Name:            "",
+						UID:             "fake-uid",
+						ResourceVersion: "fake-version",
+					},
+				},
+			},
+			setup: func() {
+				getPersistentVolume = func(_ context.Context, _ connection.RemoteClusterClient, _ string) (*v1.PersistentVolume, error) {
+					return nil, errors.New("Error retrieving PV")
+				}
+			},
+			expectedErr: true,
+		},
+		{
+			name:   "Error in updating persisitent volume",
+			pvName: "fake-pv",
+			pv: &corev1.PersistentVolume{
+				Spec: corev1.PersistentVolumeSpec{
+					ClaimRef: &corev1.ObjectReference{
+						Kind:            "PersistentVolumeClaim",
+						Namespace:       "fake-ns",
+						Name:            "",
+						UID:             "fake-uid",
+						ResourceVersion: "fake-version",
+					},
+				},
+			},
+			setup: func() {
+				pv := &corev1.PersistentVolume{}
+				getPersistentVolume = func(_ context.Context, _ connection.RemoteClusterClient, _ string) (*v1.PersistentVolume, error) {
+					return pv, nil
+				}
+				updatePersistentVolume = func(_ context.Context, _ connection.RemoteClusterClient, _ *v1.PersistentVolume) error {
+					return errors.New("error updating PV")
+				}
+			},
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer after()
+			tt.setup()
+			pvName := tt.pvName
+			pvcNamespace := tt.pvcNamespace
+			pvcResourceVersion := tt.pvcResourceVersion
+			pvcName := tt.pvcName
+			pvcUID := tt.pvcUID
+			log := tt.log
+			client := tt.client
+			ctx := context.Background()
+			err := updatePVClaimRef(ctx, client, pvName, pvcNamespace, pvcResourceVersion, pvcName, pvcUID, log)
+			if tt.expectedErr {
+				if tt.name == "Error in getting persisitent volume" && err.Error() != "Error retrieving PV" {
+					t.Errorf("expected error, got %s", err)
+				} else if tt.name == "Error in updating persisitent volume" && !strings.Contains(err.Error(), "error updating PV") {
+					t.Errorf("expected error, got %s", err)
+				}
+			} else {
+				t.Logf("Expected no error, got %s", err)
+			}
+		})
+	}
+}
+
+func TestRemovePVClaimRef(t *testing.T) {
+	originalGetPersistentVolume := getPersistentVolume
+	originalUpdatePersistentVolume := updatePersistentVolume
+
+	after := func() {
+		getPersistentVolume = originalGetPersistentVolume
+		updatePersistentVolume = originalUpdatePersistentVolume
+	}
+
+	tests := []struct {
+		name         string
+		pv           *v1.PersistentVolume
+		client       connection.RemoteClusterClient
+		pvName       string
+		pvcNamespace string
+		pvcName      string
+		log          logr.Logger
+		setup        func()
+		expectedErr  bool
+	}{
+		{
+			name: "When PV cannot be retrieved",
+			pv: &corev1.PersistentVolume{
+				Spec: corev1.PersistentVolumeSpec{
+					ClaimRef: nil,
+				},
+			},
+			setup: func() {
+				getPersistentVolume = func(_ context.Context, _ connection.RemoteClusterClient, _ string) (*v1.PersistentVolume, error) {
+					return nil, errors.New("Error retrieving PV")
+				}
+			},
+		},
+		{
+			name:   "Error in updating persisitent volume",
+			pvName: "fake-pv",
+			pv: &corev1.PersistentVolume{
+				Spec: corev1.PersistentVolumeSpec{
+					ClaimRef: &corev1.ObjectReference{
+						Kind:            "PersistentVolumeClaim",
+						Namespace:       "fake-ns",
+						Name:            "",
+						UID:             "fake-uid",
+						ResourceVersion: "fake-version",
+					},
+				},
+			},
+			setup: func() {
+				pv := &corev1.PersistentVolume{}
+				getPersistentVolume = func(_ context.Context, _ connection.RemoteClusterClient, _ string) (*v1.PersistentVolume, error) {
+					return pv, nil
+				}
+				updatePersistentVolume = func(_ context.Context, _ connection.RemoteClusterClient, _ *v1.PersistentVolume) error {
+					return errors.New("error updating PV")
+				}
+			},
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer after()
+			tt.setup()
+			pvName := tt.pvName
+			pvcNamespace := tt.pvcNamespace
+			pvcName := tt.pvcName
+			log := tt.log
+			client := tt.client
+			ctx := context.Background()
+			err := removePVClaimRef(ctx, client, pvName, pvcNamespace, pvcName, log)
+			if tt.expectedErr && err != nil {
+				if tt.name == "When PV cannot be retrieved" && err.Error() != "Error retrieving PV" {
+					t.Errorf("expected error, got %s", err)
+				} else if tt.name == "Error in updating persisitent volume" && !strings.Contains(err.Error(), "error updating PV") {
+					t.Errorf("expected error, got %s", err)
+				}
+			} else {
+				t.Logf("Expected no error, got %s", err)
+			}
+		})
+	}
+}
+
+func TestSetPVClaimRef(t *testing.T) {
+	originalGetPersistentVolume := getPersistentVolume
+	originalUpdatePersistentVolume := updatePersistentVolume
+
+	after := func() {
+		getPersistentVolume = originalGetPersistentVolume
+		updatePersistentVolume = originalUpdatePersistentVolume
+	}
+
+	tests := []struct {
+		name         string
+		pv           *v1.PersistentVolume
+		client       connection.RemoteClusterClient
+		pvName       string
+		pvcNamespace string
+		pvcName      string
+		log          logr.Logger
+		setup        func()
+		expectedErr  bool
+	}{
+		{
+			name: "When PV cannot be retrieved",
+			pv: &corev1.PersistentVolume{
+				Spec: corev1.PersistentVolumeSpec{
+					ClaimRef: nil,
+				},
+			},
+			setup: func() {
+				getPersistentVolume = func(_ context.Context, _ connection.RemoteClusterClient, _ string) (*v1.PersistentVolume, error) {
+					return nil, errors.New("Error retrieving PV")
+				}
+			},
+		},
+		{
+			name:   "Error in updating persisitent volume",
+			pvName: "fake-pv",
+			pv: &corev1.PersistentVolume{
+				Spec: corev1.PersistentVolumeSpec{
+					ClaimRef: &corev1.ObjectReference{
+						Kind:            "PersistentVolumeClaim",
+						Namespace:       "fake-ns",
+						Name:            "",
+						UID:             "fake-uid",
+						ResourceVersion: "fake-version",
+					},
+				},
+			},
+			setup: func() {
+				pv := &corev1.PersistentVolume{}
+				getPersistentVolume = func(_ context.Context, _ connection.RemoteClusterClient, _ string) (*v1.PersistentVolume, error) {
+					return pv, nil
+				}
+				updatePersistentVolume = func(_ context.Context, _ connection.RemoteClusterClient, _ *v1.PersistentVolume) error {
+					return errors.New("error updating PV")
+				}
+			},
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer after()
+			tt.setup()
+			pv := &corev1.PersistentVolume{
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeReclaimPolicy: v1.PersistentVolumeReclaimRetain,
+				},
+			}
+			pvName := tt.pvName
+			prevPolicy := pv.Spec.PersistentVolumeReclaimPolicy
+			client := tt.client
+			ctx := context.Background()
+			err := setPVReclaimPolicy(ctx, client, pvName, prevPolicy)
+			if tt.expectedErr && err != nil {
+				if tt.name == "When PV cannot be retrieved" && err.Error() != "Error retrieving PV" {
+					t.Errorf("expected error, got %s", err)
+				} else if tt.name == "Error in updating persisitent volume" && !strings.Contains(err.Error(), "error updating PV") {
+					t.Errorf("expected error, got %s", err)
+				}
+			} else {
+				t.Logf("Expected no error, got %s", err)
+			}
+		})
+	}
+}
+
+func TestSwapPVC(t *testing.T) {
+	originalGetPersistentVolumeClaim := getPersistentVolumeClaim
+	originalGetPersistentVolume := getPersistentVolume
+
+	after := func() {
+		getPersistentVolumeClaim = originalGetPersistentVolumeClaim
+		getPersistentVolume = originalGetPersistentVolume
+	}
+	tests := []struct {
+		name        string
+		pvc         *v1.PersistentVolumeClaim
+		client      connection.RemoteClusterClient
+		pvcName     string
+		namespace   string
+		targetPV    string
+		rgTarget    string
+		log         logr.Logger
+		setup       func()
+		expectedErr bool
+	}{
+		{
+			name:      "Error getting PVC",
+			namespace: "fake-ns",
+			pvcName:   "fake-pvc",
+			setup: func() {
+				getPersistentVolumeClaim = func(_ context.Context, _ connection.RemoteClusterClient, _ string, _ string) (*v1.PersistentVolumeClaim, error) {
+					return nil, errors.New("error getting pvc")
+				}
+			},
+			expectedErr: true,
+		},
+		{
+			name:      "Error getting PV",
+			namespace: "fake-ns",
+			pvcName:   "fake-pvc",
+			setup: func() {
+				pvc := &corev1.PersistentVolumeClaim{}
+				getPersistentVolumeClaim = func(_ context.Context, _ connection.RemoteClusterClient, _ string, _ string) (*v1.PersistentVolumeClaim, error) {
+					return pvc, nil
+				}
+				getPersistentVolume = func(_ context.Context, _ connection.RemoteClusterClient, _ string) (*v1.PersistentVolume, error) {
+					return nil, errors.New("error getting pv")
+				}
+			},
+			expectedErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setup()
+			defer after()
+			pvcName := tt.pvcName
+			namespace := tt.namespace
+			targetPV := tt.targetPV
+			rgTarget := tt.rgTarget
+			log := tt.log
+			client := tt.client
+			ctx := context.Background()
+			r := &ReplicationGroupReconciler{
+				Client:          nil,
+				Log:             ctrl.Log.WithName("controllers").WithName("DellCSIReplicationGroup"),
+				Scheme:          nil,
+				EventRecorder:   nil,
+				Config:          nil,
+				Domain:          "",
+				DisablePVCRemap: false,
+			}
+			err := r.swapPVC(ctx, client, pvcName, namespace, targetPV, rgTarget, log)
+			if tt.expectedErr {
+				if tt.name == "Error getting PVC" && !strings.Contains(err.Error(), "error getting pvc") {
+					t.Errorf("expected error, got %s", err)
+				} else if tt.name == "Error getting PV" && !strings.Contains(err.Error(), "error retrieving local PV") {
+					t.Errorf("expected error, got %s", err)
+				}
+			} else {
+				t.Logf("Expected no error, got %s", err)
 			}
 		})
 	}

--- a/pkg/connection/interface.go
+++ b/pkg/connection/interface.go
@@ -22,6 +22,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	storageV1 "k8s.io/api/storage/v1"
 	apiExtensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	ctrlClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // RemoteClusterClient interface provides methods for creating, modifying, deleting objects on a remote k8s cluster
@@ -36,6 +37,9 @@ type RemoteClusterClient interface {
 	UpdatePersistentVolume(ctx context.Context, volume *corev1.PersistentVolume) error
 	GetPersistentVolumeClaim(ctx context.Context, namespace, claimName string) (*corev1.PersistentVolumeClaim, error)
 	UpdatePersistentVolumeClaim(ctx context.Context, claim *corev1.PersistentVolumeClaim) error
+	CreatePersistentVolumeClaim(ctx context.Context, claim *corev1.PersistentVolumeClaim) error
+	DeletePersistentVolumeClaim(ctx context.Context, claim *corev1.PersistentVolumeClaim) error
+	ListPersistentVolumeClaim(ctx context.Context, opts ...ctrlClient.ListOption) (*corev1.PersistentVolumeClaimList, error)
 	GetReplicationGroup(ctx context.Context, replicationGroupName string) (*repv1.DellCSIReplicationGroup, error)
 	UpdateReplicationGroup(ctx context.Context, group *repv1.DellCSIReplicationGroup) error
 	ListReplicationGroup(ctx context.Context) (*repv1.DellCSIReplicationGroupList, error)

--- a/pkg/connection/k8sconnections.go
+++ b/pkg/connection/k8sconnections.go
@@ -259,9 +259,31 @@ func (c *RemoteK8sControllerClient) GetPersistentVolumeClaim(ctx context.Context
 	return claim, nil
 }
 
+// CreatePersistentVolumeClaim returns persistent volume claim object in current cluster
+func (c *RemoteK8sControllerClient) CreatePersistentVolumeClaim(ctx context.Context, claim *corev1.PersistentVolumeClaim) error {
+	return c.Client.Create(ctx, claim)
+}
+
+// DeletePersistentVolumeClaim deletes the persistent volume claim object in current cluster
+func (c *RemoteK8sControllerClient) DeletePersistentVolumeClaim(ctx context.Context, claim *corev1.PersistentVolumeClaim) error {
+	return c.Client.Delete(ctx, claim)
+}
+
 // UpdatePersistentVolumeClaim updates persistent volume claim object in current cluster
 func (c *RemoteK8sControllerClient) UpdatePersistentVolumeClaim(ctx context.Context, claim *corev1.PersistentVolumeClaim) error {
 	return c.Client.Update(ctx, claim)
+}
+
+// ListPersistentVolumeClaim gets the list of persistent volume claim objects under the replication group
+func (c *RemoteK8sControllerClient) ListPersistentVolumeClaim(ctx context.Context, opts ...ctrlClient.ListOption) (*corev1.PersistentVolumeClaimList, error) {
+	list := &corev1.PersistentVolumeClaimList{}
+
+	err := c.Client.List(ctx, list, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return list, nil
 }
 
 // CreateSnapshotContent creates the snapshot content on the remote cluster


### PR DESCRIPTION
# Description
- Contains changes for PVC remap feature changes rebased on top of the latest commits. Original changes are part of the PR 
https://github.com/dell/csm-replication/pull/147
- Increased the UT coverage 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1850|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
-Tested the functionality for PowerFlex on single cluster - Deatiled Test screenshots are captured as part of ECS01C-90
-Tested the functionality for PowerScale on stretched cluster - TDeatiled est screenshots are captured as part of ECS01C-87

Before Failover:
![image](https://github.com/user-attachments/assets/bced8eb8-832f-4246-b07e-3af749f2bf3f)
![image](https://github.com/user-attachments/assets/651c9c56-2a36-43ca-b8e9-ab45d5fbc246)

After Failover:
![image](https://github.com/user-attachments/assets/8c263fc6-5031-4fa0-a5e1-d192d21d117c)
![image](https://github.com/user-attachments/assets/fba76644-60d0-4c49-920c-b514e6c2594e)
![image](https://github.com/user-attachments/assets/17dc84c1-76ce-4915-be2c-25364bba7dcd)


