### PR TITLE
Claim ref feature

### DIFF
--- a/cmd/replication-controller/main.go
+++ b/cmd/replication-controller/main.go
@@ -119,6 +119,7 @@ var (
 		flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 			"Enable leader election for dell-replication-controller manager. "+
 				"Enabling this will ensure there is only one active dell-replication-controller manager.")
+		flag.BoolVar(&allowPVCCreationOnTarget, "allow-pvc-creation-on-target", false, "Allow PVC creation on target cluster")
 		flag.DurationVar(&retryIntervalStart, "retry-interval-start", time.Second, "Initial retry interval of failed reconcile request. It doubles with each failure, upto retry-interval-max")
 		flag.DurationVar(&retryIntervalMax, "retry-interval-max", 5*time.Minute, "Maximum retry interval of failed reconcile request")
 		flag.IntVar(&workerThreads, "worker-threads", 2, "Number of concurrent reconcilers for each of the controllers")

--- a/cmd/replication-controller/main.go
+++ b/cmd/replication-controller/main.go
@@ -119,7 +119,6 @@ var (
 		flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 			"Enable leader election for dell-replication-controller manager. "+
 				"Enabling this will ensure there is only one active dell-replication-controller manager.")
-		flag.BoolVar(&allowPVCCreationOnTarget, "allow-pvc-creation-on-target", false, "Allow PVC creation on target cluster")
 		flag.DurationVar(&retryIntervalStart, "retry-interval-start", time.Second, "Initial retry interval of failed reconcile request. It doubles with each failure, upto retry-interval-max")
 		flag.DurationVar(&retryIntervalMax, "retry-interval-max", 5*time.Minute, "Maximum retry interval of failed reconcile request")
 		flag.IntVar(&workerThreads, "worker-threads", 2, "Number of concurrent reconcilers for each of the controllers")

--- a/controllers/replication-controller/persistentvolume_controller.go
+++ b/controllers/replication-controller/persistentvolume_controller.go
@@ -356,10 +356,14 @@ func (r *PersistentVolumeReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		// 2. The remotePVCNamespace and remotePVName must be supplied.
 		if createRemotePV {
 			log.V(common.DebugLevel).Info(fmt.Sprintf("checking for need to create claimRef on remote PV: %+v", pv))
-			remoteVolume, _ := getValueFromAnnotations(controller.RemoteVolumeAnnotation, pv.Annotations)
-			remotePVCNamespace, _ := getValueFromAnnotations(controller.RemotePVCNamespace, pv.Annotations)
-			remotePVCName, _ := getValueFromAnnotations(controller.RemotePVC, pv.Annotations)
-			remoteClusterID, _ := getValueFromAnnotations(controller.RemoteClusterID, pv.Annotations)
+			remoteVolume, err := getValueFromAnnotations(controller.RemoteVolumeAnnotation, pv.Annotations)
+			remotePVCNamespace, err := getValueFromAnnotations(controller.RemotePVCNamespace, pv.Annotations)
+			remotePVCName, err := getValueFromAnnotations(controller.RemotePVC, pv.Annotations)
+			remoteClusterID, err := getValueFromAnnotations(controller.RemoteClusterID, pv.Annotations)
+			if err != nil {
+				log.Error(err, "Failed to fetch the annotation to update claim-ref")
+				return ctrl.Result{}, err
+			}
 			if remoteVolume == "" && remotePVCNamespace != "" && remotePVCName != "" {
 				if remoteClusterID == controller.Self {
 					// If single cluster replication, just make the namespace/name in the claim "reserved"

--- a/controllers/replication-controller/persistentvolume_controller.go
+++ b/controllers/replication-controller/persistentvolume_controller.go
@@ -612,6 +612,9 @@ func UpdateRemotePVDetails(ctx context.Context, client connection.RemoteClusterC
 	if volume.Spec.ClaimRef != nil && remoteClusterID != controller.Self {
 		if remotePV.Spec.ClaimRef != nil && volume.Spec.ClaimRef.Name != remotePV.Spec.ClaimRef.Name {
 			log.V(common.InfoLevel).Info(fmt.Sprintf("Remote PV claimref differs from the local PV claimref. Hence updating remote PV"))
+			remotePV.Spec.ClaimRef.Namespace = volume.Spec.ClaimRef.Namespace
+			remotePV.Spec.ClaimRef.Name = volume.Spec.ClaimRef.Name
+			remotePV.Spec.ClaimRef.ResourceVersion = volume.Spec.ClaimRef.ResourceVersion
 			remotePV.Annotations[controller.RemotePVC] = volume.Spec.ClaimRef.Name
 			remotePV.Annotations[controller.RemotePVCNamespace] = volume.Spec.ClaimRef.Namespace
 			err := client.UpdatePersistentVolume(ctx, remotePV)

--- a/controllers/replication-controller/persistentvolume_controller.go
+++ b/controllers/replication-controller/persistentvolume_controller.go
@@ -375,9 +375,6 @@ func (r *PersistentVolumeReconciler) Reconcile(ctx context.Context, req ctrl.Req
 				pv.Spec.ClaimRef = claimRef
 				log.V(common.InfoLevel).Info(fmt.Sprintf("added remote pv %s claimref %s/%s", pv.Name, remotePVCNamespace, remotePVCName))
 			}
-		}
-
-		if createRemotePV {
 			// We need to create the PV
 			err = rClient.CreatePersistentVolume(ctx, pv)
 			if err != nil {

--- a/controllers/replication-controller/persistentvolume_controller.go
+++ b/controllers/replication-controller/persistentvolume_controller.go
@@ -350,6 +350,33 @@ func (r *PersistentVolumeReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			return ctrl.Result{}, err
 		}
 
+		// Watson: If we're creating the remote PV, let's add a claimRef so the PV can only be used with
+		// a pvc of the specified namespace/name. Criteria
+		// 1. Should have no remoteVolume annotation, this is only on source and is the volume handle for the remove volume
+		// 2. The remotePVCNamespace and remotePVName must be supplied.
+		if createRemotePV {
+			log.V(common.DebugLevel).Info(fmt.Sprintf("checking for need to create claimRef on remote PV: %+v", pv))
+			remoteVolume, _ := getValueFromAnnotations(controller.RemoteVolumeAnnotation, pv.Annotations)
+			remotePVCNamespace, _ := getValueFromAnnotations(controller.RemotePVCNamespace, pv.Annotations)
+			remotePVCName, _ := getValueFromAnnotations(controller.RemotePVC, pv.Annotations)
+			remoteClusterID, _ := getValueFromAnnotations(controller.RemoteClusterID, pv.Annotations)
+			if remoteVolume == "" && remotePVCNamespace != "" && remotePVCName != "" {
+				if remoteClusterID == controller.Self {
+					// If single cluster replication, just make the namespace/name in the claim "reserved"
+					remotePVCNamespace = "reserved"
+					remotePVCName = "reserved"
+				}
+				claimRef := &v1.ObjectReference{
+					APIVersion: "v1",
+					Kind:       "PersistentVolumeClaim",
+					Name:       remotePVCName,
+					Namespace:  remotePVCNamespace,
+				}
+				pv.Spec.ClaimRef = claimRef
+				log.V(common.InfoLevel).Info(fmt.Sprintf("added remote pv %s claimref %s/%s", pv.Name, remotePVCNamespace, remotePVCName))
+			}
+		}
+
 		if createRemotePV {
 			// We need to create the PV
 			err = rClient.CreatePersistentVolume(ctx, pv)

--- a/controllers/replication-controller/persistentvolumeclaim_controller.go
+++ b/controllers/replication-controller/persistentvolumeclaim_controller.go
@@ -148,7 +148,7 @@ func (r *PersistentVolumeClaimReconciler) Reconcile(ctx context.Context, req ctr
 	remotePVCName := ""
 	remotePVCNamespace := ""
 	if remoteClusterID != controller.Self && r.AllowPVCCreationOnTarget {
-		//if its not single cluster then check the pv status and create pvc on target cluster
+		// if its not single cluster then check the pv status and create pvc on target cluster
 		if remotePV.Status.Phase == v1.VolumeAvailable && remotePV.Spec.ClaimRef != nil {
 			remoteClaim.Spec.AccessModes = remotePV.Spec.AccessModes
 			remoteClaim.Spec.Resources.Requests = v1.ResourceList{

--- a/controllers/replication-controller/persistentvolumeclaim_controller.go
+++ b/controllers/replication-controller/persistentvolumeclaim_controller.go
@@ -154,18 +154,18 @@ func (r *PersistentVolumeClaimReconciler) Reconcile(ctx context.Context, req ctr
 			remoteClaim.Spec.Resources.Requests = v1.ResourceList{
 				v1.ResourceStorage: remotePV.Spec.Capacity[v1.ResourceStorage],
 			}
-			//updating pvc annotations
+			// updating pvc annotations
 			updatePVCAnnotations(remoteClaim, remoteClusterID, remotePV)
-			//Adding finalizer to pvc
+			// Adding finalizer to pvc
 			remoteClaim.Finalizers = []string{controller.ReplicationFinalizer}
-			//updating pvc labels
+			// updating pvc labels
 			updatePVCLabels(remoteClaim, claim, remoteClusterID)
-			//Check if the namespace exists
+			// Check if the namespace exists
 			err := VerifyNamespaceExistence(ctx, rClient, remoteClaim.Namespace)
 			if err != nil {
 				return ctrl.Result{}, err
 			}
-			//creating PVC on target
+			// creating PVC on target
 			err = rClient.CreatePersistentVolumeClaim(ctx, remoteClaim)
 			if err != nil {
 				log.Error(err, "Failed to create remote PVC on target cluster")
@@ -299,10 +299,10 @@ func pvcProtectionIsComplete() predicate.Predicate {
 
 func updatePVCAnnotations(pvc *v1.PersistentVolumeClaim, remoteClusterID string, pv *v1.PersistentVolume) {
 
-	//Context prefix
+	// Context prefix
 	contextPrefix, _ := getValueFromAnnotations(controller.ContextPrefix, pv.Annotations)
 	controller.AddAnnotation(pvc, controller.ContextPrefix, contextPrefix)
-	//pvc protection complete
+	// pvc protection complete
 	pvcProtectionComplete, _ := getValueFromAnnotations(controller.PVCProtectionComplete, pv.Annotations)
 	controller.AddAnnotation(pvc, controller.PVCProtectionComplete, pvcProtectionComplete)
 	// Created By
@@ -313,24 +313,24 @@ func updatePVCAnnotations(pvc *v1.PersistentVolumeClaim, remoteClusterID string,
 	controller.AddAnnotation(pvc, controller.RemotePV, remoteVolume)
 	// Remote ClusterID
 	controller.AddAnnotation(pvc, controller.RemoteClusterID, remoteClusterID)
-	//Replication group
+	// Replication group
 	controller.AddAnnotation(pvc, controller.ReplicationGroup, pv.Labels[controller.ReplicationGroup])
 	// Remote Storage Class
 	pvc.Spec.StorageClassName = &pv.Spec.StorageClassName
 	controller.AddAnnotation(pvc, controller.RemoteStorageClassAnnotation, pv.Spec.StorageClassName)
-	//Remote Volume
+	// Remote Volume
 	remoteVolume, _ = getValueFromAnnotations(controller.RemoteVolumeAnnotation, pv.Annotations)
 	controller.AddAnnotation(pvc, controller.RemoteVolumeAnnotation, remoteVolume)
-	//remote PVC namespace
+	// remote PVC namespace
 	remotePVCNamespace, _ := getValueFromAnnotations(controller.RemotePVCNamespace, pv.Annotations)
 	pvc.Namespace = remotePVCNamespace
 	controller.AddAnnotation(pvc, controller.RemotePVCNamespace, remotePVCNamespace)
-	//remote PVC name
+	// remote PVC name
 	remotePVCName, _ := getValueFromAnnotations(controller.RemotePVC, pv.Annotations)
 	pvc.Name = remotePVCName
 	controller.AddAnnotation(pvc, controller.RemotePVC, remotePVCName)
 
-	//Remote PV Annotation
+	// Remote PV Annotation
 	remotePVString := fmt.Sprintf("%s/%s", pv.Namespace, pv.Name)
 	if pv.Annotations != nil {
 		remotePVString += fmt.Sprintf(" annotations: %v", pv.Annotations)

--- a/controllers/replication-controller/persistentvolumeclaim_controller.go
+++ b/controllers/replication-controller/persistentvolumeclaim_controller.go
@@ -17,8 +17,9 @@ package replicationcontroller
 import (
 	"context"
 	"fmt"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	controller "github.com/dell/csm-replication/controllers"
 	"github.com/dell/csm-replication/pkg/common"

--- a/controllers/replication-controller/persistentvolumeclaim_controller.go
+++ b/controllers/replication-controller/persistentvolumeclaim_controller.go
@@ -298,7 +298,6 @@ func pvcProtectionIsComplete() predicate.Predicate {
 }
 
 func updatePVCAnnotations(pvc *v1.PersistentVolumeClaim, remoteClusterID string, pv *v1.PersistentVolume) {
-
 	// Context prefix
 	contextPrefix, _ := getValueFromAnnotations(controller.ContextPrefix, pv.Annotations)
 	controller.AddAnnotation(pvc, controller.ContextPrefix, contextPrefix)

--- a/controllers/replication-controller/persistentvolumeclaim_controller.go
+++ b/controllers/replication-controller/persistentvolumeclaim_controller.go
@@ -153,10 +153,8 @@ func (r *PersistentVolumeClaimReconciler) Reconcile(ctx context.Context, req ctr
 			remoteClaim.Spec.Resources.Requests = v1.ResourceList{
 				v1.ResourceStorage: remotePV.Spec.Capacity[v1.ResourceStorage],
 			}
-			requests := remoteClaim.Spec.Resources.Requests
-			requestsStr := fmt.Sprintf("%v", requests)
 			//updating pvc annotations
-			updatePVCAnnotations(remoteClaim, remoteClusterID, requestsStr, remotePV)
+			updatePVCAnnotations(remoteClaim, remoteClusterID, remotePV)
 			//Adding finalizer to pvc
 			remoteClaim.Finalizers = []string{controller.ReplicationFinalizer}
 			//updating pvc labels
@@ -298,7 +296,7 @@ func pvcProtectionIsComplete() predicate.Predicate {
 	})
 }
 
-func updatePVCAnnotations(pvc *v1.PersistentVolumeClaim, remoteClusterID, resourceRequest string, pv *v1.PersistentVolume) {
+func updatePVCAnnotations(pvc *v1.PersistentVolumeClaim, remoteClusterID string, pv *v1.PersistentVolume) {
 
 	//Context prefix
 	contextPrefix, _ := getValueFromAnnotations(controller.ContextPrefix, pv.Annotations)

--- a/controllers/replication-controller/persistentvolumeclaim_controller.go
+++ b/controllers/replication-controller/persistentvolumeclaim_controller.go
@@ -350,7 +350,6 @@ func updatePVCLabels(pvc, volume *v1.PersistentVolumeClaim, remoteClusterID stri
 }
 
 func VerifyNamespaceExistence(ctx context.Context, rClient connection.RemoteClusterClient, namespace string) error {
-
 	// Verify if the namespace exists
 	log := common.GetLoggerFromContext(ctx)
 	if _, err := rClient.GetNamespace(ctx, namespace); err != nil {

--- a/controllers/replication-controller/persistentvolumeclaim_controller_test.go
+++ b/controllers/replication-controller/persistentvolumeclaim_controller_test.go
@@ -66,38 +66,6 @@ func (suite *PVControllerTestSuite) Init() {
 	suite.fakeConfig = mocks.New("sourceCluster", "remote-123")
 }
 
-func (suite *PVControllerTestSuite) getPV() corev1.PersistentVolume {
-	// creating fake PV to use with our fake PVC
-	volumeAttributes := map[string]string{
-		"fake-CapacityGB":     "3.00",
-		"RemoteSYMID":         "000000000002",
-		"SRP":                 "SRP_1",
-		"ServiceLevel":        "Bronze",
-		"StorageGroup":        "csi-UDI-Bronze-SRP_1-SG-test-2-ASYNC",
-		"VolumeContentSource": "",
-		"storage.kubernetes.io/csiProvisionerIdentity": "1611934095007-8081-csi-fake",
-	}
-	pvObj := corev1.PersistentVolume{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "fake-pv",
-		},
-		Spec: corev1.PersistentVolumeSpec{
-			PersistentVolumeSource: corev1.PersistentVolumeSource{
-				CSI: &corev1.CSIPersistentVolumeSource{
-					Driver:           suite.driver.DriverName,
-					VolumeHandle:     "csivol-",
-					FSType:           "ext4",
-					VolumeAttributes: volumeAttributes,
-				},
-			},
-			StorageClassName: suite.driver.StorageClass,
-		},
-		Status: corev1.PersistentVolumeStatus{Phase: corev1.VolumeBound},
-	}
-
-	return pvObj
-}
-
 func (suite *PVControllerTestSuite) runFakeRemoteReplicationManager(fakeConfig connection.MultiClusterClient, remoteClient connection.RemoteClusterClient) {
 	fakeRecorder := record.NewFakeRecorder(100)
 	// Initialize the annotations & labels
@@ -215,13 +183,52 @@ func (suite *PVControllerTestSuite) runFakeRemoteReplicationManager(fakeConfig c
 	assert.NoError(suite.T(), e, "No Error while processing local PVC")
 }
 
+// Modified getPV to accept an optional name parameter
+func (suite *PVControllerTestSuite) getPV(name ...string) corev1.PersistentVolume {
+	// Use provided name or default "fake-pv"
+	pvName := "fake-pv"
+	if len(name) > 0 && name[0] != "" {
+		pvName = name[0]
+	}
+	// creating fake PV to use with our fake PVC
+	volumeAttributes := map[string]string{
+		"fake-CapacityGB":     "3.00",
+		"RemoteSYMID":         "000000000002",
+		"SRP":                 "SRP_1",
+		"ServiceLevel":        "Bronze",
+		"StorageGroup":        "csi-UDI-Bronze-SRP_1-SG-test-2-ASYNC",
+		"VolumeContentSource": "",
+		"storage.kubernetes.io/csiProvisionerIdentity": "1611934095007-8081-csi-fake",
+	}
+	pvObj := corev1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: pvName,
+		},
+		Spec: corev1.PersistentVolumeSpec{
+			PersistentVolumeSource: corev1.PersistentVolumeSource{
+				CSI: &corev1.CSIPersistentVolumeSource{
+					Driver:           suite.driver.DriverName,
+					VolumeHandle:     "csivol-",
+					FSType:           "ext4",
+					VolumeAttributes: volumeAttributes,
+				},
+			},
+			StorageClassName: suite.driver.StorageClass,
+		},
+		Status: corev1.PersistentVolumeStatus{Phase: corev1.VolumeBound},
+	}
+	return pvObj
+}
+
+// Modified TestRemoteReplication to use "fake-pv-remote-replication"
 func (suite *PVControllerTestSuite) TestRemoteReplication() {
 	ctx := context.Background()
 
 	remoteClient, err := suite.fakeConfig.GetConnection("remote-123")
 	assert.Nil(suite.T(), err)
 
-	pvObj := suite.getPV()
+	// Create a PV on the remote cluster with a unique name
+	pvObj := suite.getPV("fake-pv-remote-replication")
 	pvObj.Status.Phase = corev1.VolumeBound
 	pvObj.Spec.ClaimRef = &corev1.ObjectReference{
 		Kind:            "PersistentVolumeClaim",
@@ -234,7 +241,7 @@ func (suite *PVControllerTestSuite) TestRemoteReplication() {
 	err = remoteClient.CreatePersistentVolume(context.Background(), &pvObj)
 	assert.Nil(suite.T(), err)
 
-	// creating fake storage-class with replication params
+	// Create a fake storage class with replication params
 	parameters := map[string]string{
 		"RdfGroup":           "2",
 		"RdfMode":            "ASYNC",
@@ -256,8 +263,8 @@ func (suite *PVControllerTestSuite) TestRemoteReplication() {
 	err = suite.client.Create(ctx, &scObj)
 	assert.Nil(suite.T(), err)
 
-	// creating fake PV to use with our fake PVC
-	pvObj = suite.getPV()
+	// Create a PV in the local cluster for the fake PVC
+	pvObj = suite.getPV("fake-pv-remote-replication")
 	err = suite.client.Create(ctx, &pvObj)
 	assert.NotNil(suite.T(), pvObj)
 
@@ -267,12 +274,11 @@ func (suite *PVControllerTestSuite) TestRemoteReplication() {
 	annotations[controllers.RemoteClusterID] = "remote-123"
 	annotations[controllers.ContextPrefix] = "csi-fake"
 
-	// creating fake resource group
+	// Create a fake replication resource group
 	resourceGroup := repv1.DellCSIReplicationGroup{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "fake-rg",
 			Annotations: annotations,
-			// Namespace: suite.mockUtils.Specs.Namespace,
 		},
 		Spec: repv1.DellCSIReplicationGroupSpec{
 			DriverName:                suite.driver.DriverName,
@@ -297,6 +303,7 @@ func (suite *PVControllerTestSuite) TestRemoteReplication() {
 	}
 	err = suite.client.Create(ctx, &resourceGroup)
 
+	// Run the fake replication manager; note the PV name parameter
 	suite.runFakeRemoteReplicationManager(suite.fakeConfig, remoteClient)
 }
 
@@ -527,6 +534,107 @@ func TestPersistentVolumeClaimReconciler_processLocalPVC(t *testing.T) {
 	}
 }
 
+func (suite *PVControllerTestSuite) TestAllowPVCCreationOnTarget_CreatesRemotePVC() {
+	ctx := context.Background()
+	remoteClient, err := suite.fakeConfig.GetConnection("remote-123")
+	assert.Nil(suite.T(), err)
+	controllers.InitLabelsAndAnnotations(constants.DefaultDomain)
+
+	// Set up a remote PV in the target cluster with Phase=Available and a ClaimRef
+	pvObj := suite.getPV("pv-create-target")
+	pvObj.Status.Phase = corev1.VolumeAvailable
+	pvObj.Spec.ClaimRef = &corev1.ObjectReference{
+		Kind:       "PersistentVolumeClaim",
+		Namespace:  suite.driver.Namespace,
+		Name:       "allow-create-pvc",
+		APIVersion: "v1",
+	}
+	if pvObj.Annotations == nil {
+		pvObj.Annotations = make(map[string]string)
+	}
+	// Add required annotations so updatePVCAnnotations can fill PVC metadata
+	pvObj.Annotations[controllers.ContextPrefix] = suite.driver.DriverName
+	pvObj.Annotations[controllers.PVCProtectionComplete] = "yes"
+	pvObj.Annotations[controllers.RemoteVolumeAnnotation] = pvObj.Name
+	pvObj.Annotations[controllers.RemotePVCNamespace] = suite.driver.Namespace
+	pvObj.Annotations[controllers.RemotePVC] = "allow-create-pvc-remote"
+	// Add required labels for updatePVCLabels
+	if pvObj.Labels == nil {
+		pvObj.Labels = make(map[string]string)
+	}
+	pvObj.Labels[controllers.DriverName] = suite.driver.DriverName
+	pvObj.Labels[controllers.ReplicationGroup] = "rg0"
+	// Create the remote PV in the fake remote cluster
+	err = remoteClient.CreatePersistentVolume(ctx, &pvObj)
+	assert.Nil(suite.T(), err, "expected no error creating remote PV on target cluster")
+
+	// Set up a local PVC in the source cluster
+	pvcObj := utils.GetPVCObj("allow-create-pvc", suite.driver.Namespace, suite.driver.StorageClass)
+	pvcAnnotations := make(map[string]string)
+	pvcAnnotations[controllers.RemoteClusterID] = "remote-123"
+	pvcObj.Status.Phase = corev1.ClaimBound
+	pvcObj.Spec.VolumeName = pvObj.Name
+	pvcObj.Annotations = pvcAnnotations
+	// Add labels to local PVC so updatePVCLabels has values
+	if pvcObj.Labels == nil {
+		pvcObj.Labels = make(map[string]string)
+	}
+	pvcObj.Labels[controllers.DriverName] = suite.driver.DriverName
+	pvcObj.Labels[controllers.ReplicationGroup] = "rg0"
+	err = suite.client.Create(ctx, pvcObj)
+	assert.Nil(suite.T(), err, "expected no error creating local PVC in source cluster")
+
+	// Perform reconciliation with AllowPVCCreationOnTarget = true
+	pvcReq := reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: suite.driver.Namespace,
+			Name:      "allow-create-pvc",
+		},
+	}
+	fakeRecorder := record.NewFakeRecorder(100)
+	externalReconcile := PersistentVolumeClaimReconciler{
+		Client:                   suite.client,
+		Log:                      ctrl.Log.WithName("controllers").WithName("DellCSIReplicationGroup"),
+		Scheme:                   utils.Scheme,
+		EventRecorder:            fakeRecorder,
+		Config:                   suite.fakeConfig,
+		AllowPVCCreationOnTarget: true,
+	}
+	res, err := externalReconcile.Reconcile(ctx, pvcReq)
+	assert.Nil(suite.T(), err, "expected no error on PVC reconcile")
+	assert.False(suite.T(), res.Requeue, "expected no requeue on successful reconcile")
+
+	// Verify that the remote PVC was created in the remote cluster
+	remotePVC, err := remoteClient.GetPersistentVolumeClaim(ctx, suite.driver.Namespace, "allow-create-pvc-remote")
+	assert.Nil(suite.T(), err, "expected remote PVC to be created on target cluster")
+	assert.Equal(suite.T(), "allow-create-pvc-remote", remotePVC.Name, "remote PVC should have correct name")
+	assert.Equal(suite.T(), suite.driver.Namespace, remotePVC.Namespace, "remote PVC should have correct namespace")
+
+	// Verify metadata on the created remote PVC
+	assert.Equal(suite.T(), constants.DellReplicationController, remotePVC.Annotations[controllers.CreatedBy], "CreatedBy annotation")
+	assert.Equal(suite.T(), pvObj.Name, remotePVC.Spec.VolumeName, "PVC Spec.VolumeName should be set to remote volume name")
+	assert.Equal(suite.T(), pvObj.Name, remotePVC.Annotations[controllers.RemotePV], "RemotePV annotation")
+	assert.Equal(suite.T(), "remote-123", remotePVC.Annotations[controllers.RemoteClusterID], "RemoteClusterID annotation")
+
+	// Verify that StorageClassName is set correctly
+	if assert.NotNil(suite.T(), remotePVC.Spec.StorageClassName, "StorageClassName should be set") {
+		assert.Equal(suite.T(), suite.driver.StorageClass, *remotePVC.Spec.StorageClassName, "StorageClassName")
+	}
+	assert.Equal(suite.T(), suite.driver.StorageClass, remotePVC.Annotations[controllers.RemoteStorageClassAnnotation], "RemoteStorageClass annotation")
+
+	// Verify name/namespace annotations
+	assert.Equal(suite.T(), suite.driver.Namespace, remotePVC.Annotations[controllers.RemotePVCNamespace], "RemotePVCNamespace annotation")
+	assert.Equal(suite.T(), "allow-create-pvc-remote", remotePVC.Annotations[controllers.RemotePVC], "RemotePVC annotation")
+
+	// Verify labels on remote PVC
+	assert.Equal(suite.T(), suite.driver.DriverName, remotePVC.Labels[controllers.DriverName], "DriverName label")
+	assert.Equal(suite.T(), "remote-123", remotePVC.Labels[controllers.RemoteClusterID], "RemoteClusterID label")
+	assert.Equal(suite.T(), "rg0", remotePVC.Labels[controllers.ReplicationGroup], "ReplicationGroup label")
+
+	// Verify finalizer is added
+	assert.Contains(suite.T(), remotePVC.Finalizers, controllers.ReplicationFinalizer, "Replication finalizer should be added")
+}
+
 func TestUpdatePVCLabels(t *testing.T) {
 	// Create a fake PVC representing the original volume (with labels)
 	original := &corev1.PersistentVolumeClaim{
@@ -644,7 +752,7 @@ func TestVerifyNamespaceExistence_NamespaceCreated(t *testing.T) {
 	assert.NoError(t, err, "expected no error getting fake remote client")
 
 	namespace := "test-namespace"
-	// Ensure the namespace does not exist initially (simulated NotFound)
+
 	_, err = remoteClient.GetNamespace(ctx, namespace)
 	assert.Error(t, err, "expected error when getting non-existent namespace")
 
@@ -653,4 +761,3 @@ func TestVerifyNamespaceExistence_NamespaceCreated(t *testing.T) {
 	assert.NoError(t, err, "expected VerifyNamespaceExistence to succeed on create")
 
 }
-

--- a/controllers/replication-controller/persistentvolumeclaim_controller_test.go
+++ b/controllers/replication-controller/persistentvolumeclaim_controller_test.go
@@ -697,7 +697,7 @@ func TestUpdatePVCAnnotations(t *testing.T) {
 	}
 
 	// Call the function under test
-	updatePVCAnnotations(pvc, "remote-123", pv)
+	updatePVCAnnotationsAndSpec(pvc, "remote-123", pv)
 
 	// Verify that annotations and spec fields were set correctly
 	assert.Equal(t, "ctxPrefixVal", pvc.Annotations[controllers.ContextPrefix], "ContextPrefix annotation")
@@ -740,7 +740,7 @@ func TestVerifyNamespaceExistence_NamespaceAlreadyExists(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Call VerifyNamespaceExistence should find existing namespace and not error
-	err = VerifyNamespaceExistence(ctx, remoteClient, "existing-ns")
+	err = VerifyAndCreateNamespace(ctx, remoteClient, "existing-ns")
 	assert.NoError(t, err)
 }
 
@@ -757,6 +757,6 @@ func TestVerifyNamespaceExistence_NamespaceCreated(t *testing.T) {
 	assert.Error(t, err, "expected error when getting non-existent namespace")
 
 	// Call the function under test; it should create the namespace
-	err = VerifyNamespaceExistence(ctx, remoteClient, namespace)
+	err = VerifyAndCreateNamespace(ctx, remoteClient, namespace)
 	assert.NoError(t, err, "expected VerifyNamespaceExistence to succeed on create")
 }

--- a/controllers/replication-controller/persistentvolumeclaim_controller_test.go
+++ b/controllers/replication-controller/persistentvolumeclaim_controller_test.go
@@ -630,9 +630,6 @@ func (suite *PVControllerTestSuite) TestAllowPVCCreationOnTarget_CreatesRemotePV
 	assert.Equal(suite.T(), suite.driver.DriverName, remotePVC.Labels[controllers.DriverName], "DriverName label")
 	assert.Equal(suite.T(), "remote-123", remotePVC.Labels[controllers.RemoteClusterID], "RemoteClusterID label")
 	assert.Equal(suite.T(), "rg0", remotePVC.Labels[controllers.ReplicationGroup], "ReplicationGroup label")
-
-	// Verify finalizer is added
-	assert.Contains(suite.T(), remotePVC.Finalizers, controllers.ReplicationFinalizer, "Replication finalizer should be added")
 }
 
 func TestUpdatePVCLabels(t *testing.T) {

--- a/controllers/replication-controller/persistentvolumeclaim_controller_test.go
+++ b/controllers/replication-controller/persistentvolumeclaim_controller_test.go
@@ -183,7 +183,7 @@ func (suite *PVControllerTestSuite) runFakeRemoteReplicationManager(fakeConfig c
 	assert.NoError(suite.T(), e, "No Error while processing local PVC")
 }
 
-// Modified getPV to accept an optional name parameter
+// To create PV obj with PV name
 func (suite *PVControllerTestSuite) getPV(name ...string) corev1.PersistentVolume {
 	// Use provided name or default "fake-pv"
 	pvName := "fake-pv"

--- a/controllers/replication-controller/persistentvolumeclaim_controller_test.go
+++ b/controllers/replication-controller/persistentvolumeclaim_controller_test.go
@@ -759,5 +759,4 @@ func TestVerifyNamespaceExistence_NamespaceCreated(t *testing.T) {
 	// Call the function under test; it should create the namespace
 	err = VerifyNamespaceExistence(ctx, remoteClient, namespace)
 	assert.NoError(t, err, "expected VerifyNamespaceExistence to succeed on create")
-
 }


### PR DESCRIPTION
# Description
Whit this changes we are Generating the PVC in the target site, to reserve/bind the PV using the ClaimRef on replicated site.
Creation of the namespace if not already present on target site is also handled. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1862 |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X] Validated the pvc creation after setting the flag to true on multi cluster 
- 
![image](https://github.com/user-attachments/assets/999abecd-d3bf-471f-baba-47af4815539d)

- [X] Validated the functionality in single cluster.
![image](https://github.com/user-attachments/assets/a907ac29-3415-46e1-be37-7c52763adfea)

