### PR TITLE
Update local pv cliamref to reserved/reserved after fail over

### DIFF
--- a/controllers/replication-controller/dellcsireplicationgroup_controller.go
+++ b/controllers/replication-controller/dellcsireplicationgroup_controller.go
@@ -792,7 +792,7 @@ func removePVClaimRef(ctx context.Context, client connection.RemoteClusterClient
 		}
 
 		if pv.Spec.ClaimRef == nil {
-			log.V(common.InfoLevel).Info(fmt.Sprintf("ClaimRef removed from for LocalPV: %s", pvName))
+			log.V(common.InfoLevel).Info(fmt.Sprintf("ClaimRef removed from LocalPV: %s", pvName))
 			return nil
 		}
 		pv.Spec.ClaimRef = nil

--- a/controllers/replication-controller/dellcsireplicationgroup_controller.go
+++ b/controllers/replication-controller/dellcsireplicationgroup_controller.go
@@ -774,6 +774,7 @@ func setPVReclaimPolicy(ctx context.Context, client connection.RemoteClusterClie
 	}
 	return fmt.Errorf("timed out waiting on PV VolumeReclaimPolicy to be set to previous policy")
 }
+
 func removePVClaimRef(ctx context.Context, client connection.RemoteClusterClient, pvName, pvcNamespace, pvcName string, log logr.Logger) error {
 	log.V(common.InfoLevel).Info(fmt.Sprintf("Removing ClaimRef on LocalPV: %s", pvName))
 	for iteration := 0; iteration < 30; iteration++ {

--- a/controllers/replication-controller/dellcsireplicationgroup_controller.go
+++ b/controllers/replication-controller/dellcsireplicationgroup_controller.go
@@ -79,9 +79,17 @@ var (
 	updatePersistentVolume = func(ctx context.Context, client connection.RemoteClusterClient, pv *v1.PersistentVolume) error {
 		return client.UpdatePersistentVolume(ctx, pv)
 	}
-
+	deletePersistentVolumeClaim = func(ctx context.Context, client connection.RemoteClusterClient, pvc *v1.PersistentVolumeClaim) error {
+		return client.DeletePersistentVolumeClaim(ctx, pvc)
+	}
+	createPersistentVolumeClaim = func(ctx context.Context, client connection.RemoteClusterClient, pvc *v1.PersistentVolumeClaim) error {
+		return client.CreatePersistentVolumeClaim(ctx, pvc)
+	}
 	getPersistentVolumeClaim = func(ctx context.Context, client connection.RemoteClusterClient, namespace string, pvcName string) (*v1.PersistentVolumeClaim, error) {
 		return client.GetPersistentVolumeClaim(ctx, namespace, pvcName)
+	}
+	sleep = func(d time.Duration) {
+		time.Sleep(d)
 	}
 )
 
@@ -633,7 +641,7 @@ func (r *ReplicationGroupReconciler) swapPVC(ctx context.Context, client connect
 	}
 
 	// Delete the existing PVC
-	err = client.DeletePersistentVolumeClaim(ctx, pvc)
+	err = deletePersistentVolumeClaim(ctx, client, pvc)
 	if err != nil {
 		return fmt.Errorf("error deleting PVC %s with errror %s", pvcName, err)
 	}
@@ -641,7 +649,7 @@ func (r *ReplicationGroupReconciler) swapPVC(ctx context.Context, client connect
 	// Wait until PVC is deleted
 	done := false
 	for iteration := 0; !done; iteration++ {
-		time.Sleep(2 * time.Second)
+		sleep(2 * time.Second)
 		_, err := getPersistentVolumeClaim(ctx, client, namespace, pvcName)
 		if err != nil {
 			if errors.IsNotFound(err) {
@@ -670,7 +678,7 @@ func (r *ReplicationGroupReconciler) swapPVC(ctx context.Context, client connect
 	pvc.ObjectMeta.ResourceVersion = ""
 
 	// Re-create the PVC, now pointing to the target.
-	err = client.CreatePersistentVolumeClaim(ctx, pvc)
+	err = createPersistentVolumeClaim(ctx, client, pvc)
 	if err != nil {
 		return fmt.Errorf("unable to create PVC %s: %s", pvc.Name, err.Error())
 	}
@@ -718,7 +726,7 @@ func (r *ReplicationGroupReconciler) swapPVC(ctx context.Context, client connect
 		}
 
 		log.V(common.InfoLevel).Info(fmt.Sprintf("Issue updating PV %s so trying again", localPV))
-		time.Sleep(2 * time.Second)
+		sleep(2 * time.Second)
 	}
 
 	// Restore the PVs original volume reclaim policy
@@ -742,7 +750,7 @@ func verifyPVC(ctx context.Context, client connection.RemoteClusterClient, local
 			return nil
 		}
 
-		time.Sleep(2 * time.Second)
+		sleep(2 * time.Second)
 	}
 
 	return fmt.Errorf("timed out waiting on PVC %s/%s to be created and bound", namespace, pvcName)
@@ -770,7 +778,7 @@ func setPVReclaimPolicy(ctx context.Context, client connection.RemoteClusterClie
 			return nil
 		}
 
-		time.Sleep(2 * time.Second)
+		sleep(2 * time.Second)
 	}
 	return fmt.Errorf("timed out waiting on PV VolumeReclaimPolicy to be set to previous policy")
 }
@@ -799,7 +807,7 @@ func removePVClaimRef(ctx context.Context, client connection.RemoteClusterClient
 			}
 
 			log.V(common.InfoLevel).Info(fmt.Sprintf("Issue updating PV %s so trying again", pvName))
-			time.Sleep(2 * time.Second)
+			sleep(2 * time.Second)
 		}
 	}
 
@@ -828,7 +836,7 @@ func removeReservedClaimRefForTargetPV(ctx context.Context, client connection.Re
 			}
 
 			log.V(common.InfoLevel).Info(fmt.Sprintf("Issue updating PV %s so trying again", pvName))
-			time.Sleep(2 * time.Second)
+			sleep(2 * time.Second)
 		}
 	}
 
@@ -875,7 +883,7 @@ func updatePVClaimRef(ctx context.Context, client connection.RemoteClusterClient
 			}
 
 			log.V(common.InfoLevel).Info(fmt.Sprintf("Issue retrieving latest for %s and trying again", pvName))
-			time.Sleep(2 * time.Second)
+			sleep(2 * time.Second)
 		}
 	}
 

--- a/controllers/replication-controller/dellcsireplicationgroup_controller.go
+++ b/controllers/replication-controller/dellcsireplicationgroup_controller.go
@@ -693,7 +693,7 @@ func (r *ReplicationGroupReconciler) swapPVC(ctx context.Context, client connect
 	// Remove the PVC reclaim of local PV
 	err = removePVClaimRef(ctx, client, localPV, namespace, pvcName, log)
 	if err != nil {
-		return fmt.Errorf("error updating PV claim ref from %s: %s", localPV, err.Error())
+		return fmt.Errorf("error removing PV claim ref from %s: %s", localPV, err.Error())
 	}
 
 	// Updating the claimRef of localPV to reservd/reserved

--- a/controllers/replication-controller/dellcsireplicationgroup_controller.go
+++ b/controllers/replication-controller/dellcsireplicationgroup_controller.go
@@ -721,12 +721,7 @@ func (r *ReplicationGroupReconciler) swapPVC(ctx context.Context, client connect
 
 	err = updatePersistentVolume(ctx, client, pv)
 	if err != nil {
-		if !errors.IsConflict(err) {
-			return fmt.Errorf("error updating PV %s: %s", localPV, err.Error())
-		}
-
-		log.V(common.InfoLevel).Info(fmt.Sprintf("Issue updating PV %s so trying again", localPV))
-		sleep(2 * time.Second)
+		return fmt.Errorf("error updating PV %s: %s", localPV, err.Error())
 	}
 
 	// Restore the PVs original volume reclaim policy

--- a/controllers/replication-controller/dellcsireplicationgroup_controller.go
+++ b/controllers/replication-controller/dellcsireplicationgroup_controller.go
@@ -717,12 +717,12 @@ func (r *ReplicationGroupReconciler) swapPVC(ctx context.Context, client connect
 		Namespace:  controller.ReservedPVCNamespace,
 	}
 	pv.Spec.ClaimRef = claimRef
-	log.V(common.InfoLevel).Info(fmt.Sprintf("added remote pv %s claimref %s/%s", pv.Name, controller.ReservedPVCName, controller.ReservedPVCNamespace))
 
 	err = updatePersistentVolume(ctx, client, pv)
 	if err != nil {
 		return fmt.Errorf("error updating PV %s: %s", localPV, err.Error())
 	}
+	log.V(common.InfoLevel).Info(fmt.Sprintf("added remote pv %s claimref %s/%s", pv.Name, controller.ReservedPVCName, controller.ReservedPVCNamespace))
 
 	// Restore the PVs original volume reclaim policy
 	err = setPVReclaimPolicy(ctx, client, pvc.Spec.VolumeName, remotePVPolicy)

--- a/controllers/replication-controller/dellcsireplicationgroup_controller_test.go
+++ b/controllers/replication-controller/dellcsireplicationgroup_controller_test.go
@@ -1470,7 +1470,7 @@ func TestUpdatePVClaimRef(t *testing.T) {
 	}
 }
 
-func TestRemovePVClaimRef(t *testing.T) {
+func TestUpdaetPVClaimRefForLocalPV(t *testing.T) {
 	originalGetPersistentVolume := getPersistentVolume
 	originalUpdatePersistentVolume := updatePersistentVolume
 
@@ -1518,7 +1518,17 @@ func TestRemovePVClaimRef(t *testing.T) {
 				},
 			},
 			setup: func() {
-				pv := &corev1.PersistentVolume{}
+				pv := &corev1.PersistentVolume{
+					Spec: corev1.PersistentVolumeSpec{
+						ClaimRef: &corev1.ObjectReference{
+							Kind:            "PersistentVolumeClaim",
+							Namespace:       "fake-ns",
+							Name:            "",
+							UID:             "fake-uid",
+							ResourceVersion: "fake-version",
+						},
+					},
+				}
 				getPersistentVolume = func(_ context.Context, _ connection.RemoteClusterClient, _ string) (*v1.PersistentVolume, error) {
 					return pv, nil
 				}
@@ -1540,7 +1550,7 @@ func TestRemovePVClaimRef(t *testing.T) {
 			log := tt.log
 			client := tt.client
 			ctx := context.Background()
-			err := removePVClaimRef(ctx, client, pvName, pvcNamespace, pvcName, log)
+			err := updatePVClaimRefForLocalPV(ctx, client, pvName, pvcNamespace, pvcName, log)
 			if tt.expectedErr && err != nil {
 				if tt.name == "When PV cannot be retrieved" && err.Error() != "Error retrieving PV" {
 					t.Errorf("expected error, got %s", err)

--- a/controllers/replication-controller/dellcsireplicationgroup_controller_test.go
+++ b/controllers/replication-controller/dellcsireplicationgroup_controller_test.go
@@ -1206,7 +1206,8 @@ func (suite *RGControllerTestSuite) TestPVCRemapPlanned() {
 	var updatedLocalPV corev1.PersistentVolume
 	err = suite.client.Get(context.Background(), types.NamespacedName{Name: "local-pv"}, &updatedLocalPV)
 	suite.NoError(err)
-	suite.Nil(updatedLocalPV.Spec.ClaimRef, "Local PV's claim reference should be removed")
+	suite.Equal("reserved", updatedLocalPV.Spec.ClaimRef.Name, "Remote PV should now be claimed by the PVC")
+	suite.Equal("reserved", updatedLocalPV.Spec.ClaimRef.Namespace)
 	suite.Equal(controllers.RemoteRetentionValueDelete, string(updatedLocalPV.Spec.PersistentVolumeReclaimPolicy), "Local PV reclaim policy should be 'Delete' after swapAllPVC")
 }
 
@@ -1261,7 +1262,8 @@ func (suite *RGControllerTestSuite) TestPVCRemapUnplanned() {
 	var updatedLocalPV corev1.PersistentVolume
 	err = suite.client.Get(context.Background(), types.NamespacedName{Name: "local-pv"}, &updatedLocalPV)
 	suite.NoError(err)
-	suite.Nil(updatedLocalPV.Spec.ClaimRef, "Local PV's claim reference should be removed")
+	suite.Equal("reserved", updatedLocalPV.Spec.ClaimRef.Name, "Remote PV should now be claimed by the PVC")
+	suite.Equal("reserved", updatedLocalPV.Spec.ClaimRef.Namespace)
 	suite.Equal(controllers.RemoteRetentionValueDelete, string(updatedLocalPV.Spec.PersistentVolumeReclaimPolicy), "Local PV reclaim policy should be 'Delete' after swapAllPVC")
 }
 

--- a/controllers/replication-controller/dellcsireplicationgroup_controller_test.go
+++ b/controllers/replication-controller/dellcsireplicationgroup_controller_test.go
@@ -1425,7 +1425,7 @@ func TestUpdatePVClaimRef(t *testing.T) {
 					ClaimRef: &corev1.ObjectReference{
 						Kind:            "PersistentVolumeClaim",
 						Namespace:       "fake-ns",
-						Name:            "",
+						Name:            "fake-pvc",
 						UID:             "fake-uid",
 						ResourceVersion: "fake-version",
 					},
@@ -1470,7 +1470,7 @@ func TestUpdatePVClaimRef(t *testing.T) {
 	}
 }
 
-func TestUpdaetPVClaimRefForLocalPV(t *testing.T) {
+func TestRemovePVClaimRef(t *testing.T) {
 	originalGetPersistentVolume := getPersistentVolume
 	originalUpdatePersistentVolume := updatePersistentVolume
 
@@ -1504,14 +1504,16 @@ func TestUpdaetPVClaimRefForLocalPV(t *testing.T) {
 			},
 		},
 		{
-			name:   "Error in updating persisitent volume",
-			pvName: "fake-pv",
+			name:         "Error in updating persisitent volume",
+			pvName:       "fake-pv",
+			pvcNamespace: "fake-ns",
+			pvcName:      "fake-pvc",
 			pv: &corev1.PersistentVolume{
 				Spec: corev1.PersistentVolumeSpec{
 					ClaimRef: &corev1.ObjectReference{
 						Kind:            "PersistentVolumeClaim",
 						Namespace:       "fake-ns",
-						Name:            "",
+						Name:            "fake-pvc",
 						UID:             "fake-uid",
 						ResourceVersion: "fake-version",
 					},
@@ -1523,10 +1525,14 @@ func TestUpdaetPVClaimRefForLocalPV(t *testing.T) {
 						ClaimRef: &corev1.ObjectReference{
 							Kind:            "PersistentVolumeClaim",
 							Namespace:       "fake-ns",
-							Name:            "",
+							Name:            "fake-pvc",
 							UID:             "fake-uid",
 							ResourceVersion: "fake-version",
 						},
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: make(map[string]string),
+						Labels:      make(map[string]string),
 					},
 				}
 				getPersistentVolume = func(_ context.Context, _ connection.RemoteClusterClient, _ string) (*v1.PersistentVolume, error) {
@@ -1550,7 +1556,7 @@ func TestUpdaetPVClaimRefForLocalPV(t *testing.T) {
 			log := tt.log
 			client := tt.client
 			ctx := context.Background()
-			err := updatePVClaimRefForLocalPV(ctx, client, pvName, pvcNamespace, pvcName, log)
+			err := removePVClaimRef(ctx, client, pvName, pvcNamespace, pvcName, log)
 			if tt.expectedErr && err != nil {
 				if tt.name == "When PV cannot be retrieved" && err.Error() != "Error retrieving PV" {
 					t.Errorf("expected error, got %s", err)


### PR DESCRIPTION
# Description
In a single or stretched cluster, when a failover occurs, we remap the Persistent Volume Claim (PVC) from the source Persistent Volume (PV) to the replicated PV. However, this process leaves the claimRef field on the source PV empty, allowing any user to potentially claim it. To prevent this, this Pull Request (PR) updates the claimRef field to reserved/reserved in these scenarios, effectively blocking the PV from being claimed by unauthorized users.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1924 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Tested the Failover and reprotect workflow on single cluster for PowerFlex and the screenshots are as below:

Status of PV, PVC and RG before Failover
<img width="931" height="240" alt="image" src="https://github.com/user-attachments/assets/afb5609f-69b8-4121-aee4-926a02fb0d0e" />

Status of PV, PVC and RG after Failover (original PV "claimRef" has been updated to reserved/reserved and original PVC is now claiming to replicated PV )
<img width="915" height="419" alt="image" src="https://github.com/user-attachments/assets/b347bb20-c22c-4814-a3d7-f008bf2c342a" />

After reprotect on the RG
<img width="908" height="416" alt="image" src="https://github.com/user-attachments/assets/519ddcd8-fd53-44fc-91e2-e7160fc1a55e" />