### PR TITLE
Refactor utils pkg 

### DIFF
--- a/controllers/csi-node-rescanner/dellcsimigrationgroup_controller.go
+++ b/controllers/csi-node-rescanner/dellcsimigrationgroup_controller.go
@@ -24,7 +24,7 @@ import (
 	storagev1 "github.com/dell/csm-replication/api/v1"
 	controller "github.com/dell/csm-replication/controllers"
 	"github.com/dell/csm-replication/pkg/common/logger"
-	"github.com/dell/csm-replication/pkg/utils"
+	"github.com/dell/csm-replication/pkg/noderescan"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -126,7 +126,7 @@ func (r *NodeRescanReconciler) processMGForRescan(ctx context.Context, mg *stora
 
 	log.V(logger.DebugLevel).Info("Begin rescan on node for MG spec", "Name: ", mg.Name, "Node:", myNode.Name)
 	// Perform rescan on the node
-	err = utils.RescanNode(ctx)
+	err = noderescan.RescanNode(ctx)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/pkg/noderescan/noderescan.go
+++ b/pkg/noderescan/noderescan.go
@@ -12,7 +12,7 @@
  limitations under the License.
 */
 
-package utils
+package noderescan
 
 import (
 	"context"

--- a/pkg/noderescan/noderescan_test.go
+++ b/pkg/noderescan/noderescan_test.go
@@ -12,10 +12,7 @@
  limitations under the License.
 */
 
-// revive:disable:var-naming
-package utils
-
-// revive:enable:var-naming
+package noderescan
 
 import (
 	"context"


### PR DESCRIPTION
# Description
This PR refactors the `utils` package to `noderecan` to comply with our linter's 'unhelpful name' rule and improve code clarity.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1896 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Verified build is successful
```
# make build
which: no controller-gen in (/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/usr/local/go/bin)
which: no kustomize in (/root/.local/bin:/root/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/usr/local/go/bin)
(cd core; rm -f core_generated.go; go generate)
go run core/semver/semver.go -f mk > semver.mk
go fmt ./...
go vet ./...
go: creating new go.mod: module tmp
go: creating new go.mod: module tmp
/root/go/bin/controller-gen object:headerFile="hack/boilerplate.go.txt",year=2025 paths="./api/..."
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/dell-csi-replicator cmd/csi-replicator/main.go
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/dell-csi-migrator cmd/csi-migrator/main.go
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/dell-csi-node-rescanner cmd/csi-node-rescanner/main.go
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o bin/dell-replication-controller cmd/replication-controller/main.go
[root@master-1-E4hZ2l1eQqy9q csm-replication]# 
```
