### PR TITLE
Adding Powermax replication group action

### DIFF
--- a/repctl/pkg/cmd/action.go
+++ b/repctl/pkg/cmd/action.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2021-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -38,7 +38,8 @@ For single or multi-cluster config:
 ./repctl --rg <rg-id> exec -a <ACTION>
 repctl --rg <rg-id> exec -a suspend
 repctl --rg <rg-id> exec -a resume
-repctl --rg <rg-id> exec -a sync`,
+repctl --rg <rg-id> exec -a sync
+repctl --rg <rg-id> exec -a establish`,
 		Long: `
 This command will perform a maintenance on current source site. repctl will patch the CR with specified <ACTION>`,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -106,6 +107,8 @@ func getSupportedMaintenanceAction(action string) (string, error) {
 		return config.ActionSuspend, nil
 	case "sync":
 		return config.ActionSync, nil
+	case "establish":
+		return config.ActionEstablish, nil
 	}
 	return "", fmt.Errorf("not a supported action")
 }

--- a/repctl/pkg/cmd/action_test.go
+++ b/repctl/pkg/cmd/action_test.go
@@ -226,6 +226,7 @@ func TestGetSupportedMaintenanceAction(t *testing.T) {
 		{"resume", config.ActionResume, nil},
 		{"suspend", config.ActionSuspend, nil},
 		{"sync", config.ActionSync, nil},
+		{"establish", config.ActionEstablish, nil},
 		{"invalid", "", fmt.Errorf("not a supported action")},
 	}
 

--- a/repctl/pkg/config/constants.go
+++ b/repctl/pkg/config/constants.go
@@ -1,5 +1,5 @@
 /*
- Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+ Copyright © 2021-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ const (
 	ActionSuspend                = "SUSPEND"
 	ActionResume                 = "RESUME"
 	ActionSync                   = "SYNC"
+	ActionEstablish              = "ESTABLISH"
 	ActionCreateSnapshot         = "CREATE_SNAPSHOT"
 	Verbose                      = "verbose"
 )


### PR DESCRIPTION
# Description
This PR addresses gaps in karavi replication tests for powermax driver.
Powermax was missing an action for a replication group which would eventually fail the karavi tests.
Adding the "ESTABLISH" action for powermax helps in creating replication group.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/2001 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

I had successfull sync and async replication run with powermax driver
