### PR TITLE
Remove DataSource and DataSourceRef with PVCRemap

### DIFF
--- a/controllers/replication-controller/dellcsireplicationgroup_controller.go
+++ b/controllers/replication-controller/dellcsireplicationgroup_controller.go
@@ -676,6 +676,8 @@ func (r *ReplicationGroupReconciler) swapPVC(ctx context.Context, client connect
 	pvc.Labels[controller.ReplicationGroup] = rgTarget
 	pvc.Spec.StorageClassName = &remoteStorageClassName
 	pvc.ObjectMeta.ResourceVersion = ""
+	pvc.Spec.DataSource = nil
+	pvc.Spec.DataSourceRef = nil
 
 	// Re-create the PVC, now pointing to the target.
 	err = createPersistentVolumeClaim(ctx, client, pvc)

--- a/controllers/replication-controller/dellcsireplicationgroup_controller_test.go
+++ b/controllers/replication-controller/dellcsireplicationgroup_controller_test.go
@@ -1148,6 +1148,17 @@ func (suite *RGControllerTestSuite) getSingleClusterPVSetup() (*repv1.DellCSIRep
 	pvcObj.Spec.VolumeName = "local-pv"
 	pvcObj.Annotations = pvcAnnotations
 	pvcObj.Labels = pvcLabels
+	apiGroup := "cdi.kubevirt.io"
+	pvcObj.Spec.DataSourceRef = &v1.TypedObjectReference{
+		APIGroup: &apiGroup,
+		Kind:     "VolumeImportSource",
+		Name:     "fake-import",
+	}
+	pvcObj.Spec.DataSource = &v1.TypedLocalObjectReference{
+		APIGroup: &apiGroup,
+		Kind:     "VolumeImportSource",
+		Name:     "fake-import",
+	}
 
 	err = suite.client.Create(ctx, pvcObj)
 	suite.NoError(err)
@@ -1193,6 +1204,8 @@ func (suite *RGControllerTestSuite) TestPVCRemapPlanned() {
 	suite.Equal("sc-2", *swappedPVC.Spec.StorageClassName, "PVC should now use the remote storage class")
 	suite.Equal("local-pv", swappedPVC.Annotations[controllers.RemotePV], "Remote PV annotation should be updated")
 	suite.Equal(replicatedRGName, swappedPVC.Annotations[controllers.ReplicationGroup], "Replication group annotation should be updated")
+	suite.Empty(swappedPVC.Spec.DataSource)
+	suite.Empty(swappedPVC.Spec.DataSourceRef)
 
 	// Verify remote PV's claim reference
 	var updatedRemotePV corev1.PersistentVolume


### PR DESCRIPTION
This was causing issues when doing a failover and the volume was created from a CDI(containerized-data-importer)

Ticket: 219303570

# Description
Remove DataSource and DataSourceRef when doing a PVCRemap, otherwise it would import the volume again on creation

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have maintained backward compatibility

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] None unit test are enough
